### PR TITLE
[feat] Added Issue template to repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: 🐞 Bug report
+description: Create a report to help us improve (use this to report bugs only).
+title: "[BUG] <title>"
+labels: [🐞 bug]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. Include images if relevant.
+      placeholder: A bug happened!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Screenshots [optional]
+      description: |
+        Add screenshots to help explain your problem. You can also add a video here.
+
+        Tip: You can attach images or video files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the bug.
+      placeholder: |
+        1. Visit '...'
+        2. Click on '...'
+        3. Scroll to '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+    validations:
+      required: false
+  - type: dropdown
+    id: assign
+    attributes:
+      label: Are you working on this?
+      options:
+        - "Yes"
+        - "No"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: ✨ Idea [Feature request] 
+description: Tell us about the idea you have !
+title: "[Feature] <title>"
+labels: [idea]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Your suggestions are highly valuable.
+  - type: textarea
+    attributes:
+      label: Feature description
+      description: |
+        Is your feature request related to a problem? A clear and concise description of what the feature is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the solution
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe alternatives
+      description: |
+        A clear and concise description of any alternative solutions or features you have considered.
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other additional context or screenshots about the feature request here.
+  - type: dropdown
+    id: assign
+    attributes:
+      label: Are you working on this?
+      options:
+        - "Yes"
+        - "No"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea*
-.github*
+.github/*
+!.github/ISSUE_TEMPLATE/
 __pycache__/
 *.nii.gz
 bvals.txt


### PR DESCRIPTION
# Description of Changes in PR
I propose adding an issue template to this GitHub repository. 
This will ensure consistency, clarity, and efficiency in issue reporting.

# Screenshot of Changes 
## 2 types of issues  [feature request  / BUG REPORT] 
![image](https://github.com/OSIPI/TF2.4_IVIM-MRI_CodeCollection/assets/100958893/892b9efe-6cd3-493b-9173-bf9b26f4aad1)

## Feature Request 
![image](https://github.com/OSIPI/TF2.4_IVIM-MRI_CodeCollection/assets/100958893/053565e7-3563-41e4-8b81-0a6b69a89735)
![image](https://github.com/OSIPI/TF2.4_IVIM-MRI_CodeCollection/assets/100958893/26a44aa4-5c00-444c-bcf4-32dbda47f81f)


## Bug Report 
![image](https://github.com/OSIPI/TF2.4_IVIM-MRI_CodeCollection/assets/100958893/5d467610-dfb1-4a89-814a-956b1389da97)
![image](https://github.com/OSIPI/TF2.4_IVIM-MRI_CodeCollection/assets/100958893/a9f46575-ad34-41e5-b37b-bfbb62c293c4)