### PR TITLE
Add missing packages to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib
 scienceplots
 cvxpy
 pytest
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ dipy
 matplotlib
 scienceplots
 cvxpy
+pytest


### PR DESCRIPTION
While trying to run the project locally, I noticed some packages are used in the project but not present in `requirements.txt`.