### PR TITLE
Downgraded upload and download-artifact@v4 to v3

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -89,7 +89,7 @@ jobs:
     needs: build
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
       - name: Merge fitting results
@@ -127,7 +127,7 @@ jobs:
             any::data.table
             any::ggplot2
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: Data
       - name: Generate figures
@@ -164,7 +164,7 @@ jobs:
             any::tidyverse
             any::assertr
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: Data
       - name: Test against previous results

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'analysis/**'
+      - 'usman'
 
 jobs:
   algorithms:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'main'
       - 'analysis/**'
-      - 'usman'
 
 jobs:
   algorithms:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -76,7 +76,7 @@ jobs:
           source .venv/bin/activate
           python -m pytest -m slow --selectAlgorithm ${{ matrix.algorithm }} --saveFileName test_output_${{ matrix.algorithm }}_${{ matrix.SNR }}.csv --SNR ${{ matrix.SNR }} --fitCount 300 --saveDurationFileName test_duration_${{ matrix.algorithm }}_${{ matrix.SNR }}.csv
       - name: Upload raw data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
             name: Working_Data
             retention-days: 1
@@ -101,7 +101,7 @@ jobs:
           head -n 1 $(ls artifacts/Working_Data/test_duration_*.csv | head -n 1) > test_duration.csv
           tail -q -n +2 artifacts/Working_Data/test_duration_*.csv >> test_duration.csv
       - name: Upload merged artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Data
           path: |
@@ -133,7 +133,7 @@ jobs:
       - name: Generate figures
         run: Rscript --vanilla tests/IVIMmodels/unit_tests/analyze.r test_output.csv test_duration.csv
       - name: Upload figures
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: always()
         with:
             name: Figures


### PR DESCRIPTION
### Describe the changes you have made in this PR
The actions/upload-artifact@v4 actions/download-artifact@v4
and is not yet supported in GHES
See https://github.com/actions/upload-artifact/issues/478

Fixes #44

### Checklist

- [ ] Self-review of changed code
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides