### PR TITLE
Speed up the algorithm analysis workflow

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -19,17 +19,18 @@ jobs:
         with:
           python-version: "3.11"
           cache: 'pip'
-      # - name: Cache virtualenv
-      #   uses: actions/cache@v3
-      #   with:
-      #     key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version}}-${{ hashFiles('requirements.txt') }}
-      #     path: .venv
+      - name: Cache pip
+        uses: actions/cache@v3
+        id: pip-cache
+        with:
+          key: ${{ env.pythonLocation }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ${{ env.pythonLocation }}
+        if: steps.python-cache.outputs.cache-hit != 'true'
+
       - name: Install dependencies
         run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          python -m pip install -r requirements.txt
-          python -m pip install pytest
+          pip install -r requirements.txt
+
       - name: Read algorithms
         id: algorithms
         run: |
@@ -59,20 +60,16 @@ jobs:
         with:
           python-version: "3.11"
           cache: 'pip'
-      # - name: Cache virtualenv
-      #   uses: actions/cache@v3
-      #   with:
-      #     key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version}}-${{ hashFiles('requirements.txt') }}
-      #     path: .venv
-      - name: Install dependencies
-        run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          python -m pip install -r requirements.txt
-          python -m pip install pytest
+      - name: Cache pip
+        id: python-cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ env.pythonLocation }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ${{ env.pythonLocation }}
+        if: steps.python-cache.outputs.cache-hit != 'true'
+
       - name: Generate fitting data
         run: |
-          source .venv/bin/activate
           python -m pytest -m slow --selectAlgorithm ${{ matrix.algorithm }} --saveFileName test_output_${{ matrix.algorithm }}_${{ matrix.SNR }}.csv --SNR ${{ matrix.SNR }} --fitCount 300 --saveDurationFileName test_duration_${{ matrix.algorithm }}_${{ matrix.SNR }}.csv
       - name: Upload raw data
         uses: actions/upload-artifact@v3

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v3
         id: pip-cache
         with:
-          key: ${{ env.pythonLocation }}-pip-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-pip-${{ hashFiles('**/requirements.txt') }}
           path: ${{ env.pythonLocation }}
         if: steps.pip-cache.outputs.cache-hit != 'true'
 
@@ -63,7 +63,7 @@ jobs:
         id: python-cache
         uses: actions/cache@v3
         with:
-          key: ${{ env.pythonLocation }}-pip-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-pip-${{ hashFiles('**/requirements.txt') }}
           path: ${{ env.pythonLocation }}
 
       - name: Generate fitting data

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -18,14 +18,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: 'pip'
       - name: Cache pip
         uses: actions/cache@v3
         id: pip-cache
         with:
           key: ${{ env.pythonLocation }}-pip-${{ hashFiles('**/requirements.txt') }}
           path: ${{ env.pythonLocation }}
-        if: steps.python-cache.outputs.cache-hit != 'true'
+        if: steps.pip-cache.outputs.cache-hit != 'true'
 
       - name: Install dependencies
         run: |
@@ -59,14 +58,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: 'pip'
-      - name: Cache pip
+        if: steps.pip-cache.outputs.cache-hit != 'true'
+      - name: Restore cache
         id: python-cache
         uses: actions/cache@v3
         with:
           key: ${{ env.pythonLocation }}-pip-${{ hashFiles('**/requirements.txt') }}
           path: ${{ env.pythonLocation }}
-        if: steps.python-cache.outputs.cache-hit != 'true'
 
       - name: Generate fitting data
         run: |

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       # You can test your matrix by printing the current Python version
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
       # You can test your matrix by printing the current Python version
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"


### PR DESCRIPTION
Fixes #43 

- Created dependency caching for python environment.

- Separated the slow algorithms into another job that runs in parallel with the default algorithms set.

Those techniques speed up the workflow from ~25 minutes to ~15 minutes
See: https://github.com/AhmedBasem20/TF2.4_IVIM-MRI_CodeCollection/actions/runs/8149764438
