### PR TITLE
Dropped py3.8, added py3.12 & py3.13

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -11,7 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        # Windows chokes on py3.13: https://github.com/numpy/numpy/issues/27894
         # exclude:
         #   - os: macos-latest
         #     python-version: "3.7"

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         # exclude:
         #   - os: macos-latest
         #     python-version: "3.7"

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -11,13 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        exclude:
+          - os: windows-latest
+            python-version: "3.13"
         # Windows chokes on py3.13: https://github.com/numpy/numpy/issues/27894
-        # exclude:
-        #   - os: macos-latest
-        #     python-version: "3.7"
-        #   - os: windows-latest
-        #     python-version: "3.7"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
Updated the python versions to drop 3.8 and add 3.12 and 3.13. This updates it to test all current LTS python versions.