### PR TITLE
Doc: fixing required installation cell

### DIFF
--- a/doc/Introduction_to_TF24_IVIM-MRI_CodeCollection_github_and_IVIM_Analysis_using_Python.ipynb
+++ b/doc/Introduction_to_TF24_IVIM-MRI_CodeCollection_github_and_IVIM_Analysis_using_Python.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "56273b2a",
    "metadata": {},
    "outputs": [
@@ -60,10 +60,11 @@
    ],
    "source": [
     "# install packages through anaconda prompt\n",
-    "pip3 install numpy\n",
-    "pip3 install matplotlib\n",
-    "pip3 install scipy\n",
-    "pip3 install nibabel"
+    "!pip3 install numpy\n",
+    "!pip3 install matplotlib\n",
+    "!pip3 install scipy\n",
+    "!pip3 install nibabel\n",
+    "!pip3 install zenodo_get"
    ]
   },
   {
@@ -76,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "9654f12d-6cfc-4639-884e-d7f2b23fa59f",
    "metadata": {},
    "outputs": [],

--- a/doc/Introduction_to_TF24_IVIM-MRI_CodeCollection_github_and_IVIM_Analysis_using_Python.ipynb
+++ b/doc/Introduction_to_TF24_IVIM-MRI_CodeCollection_github_and_IVIM_Analysis_using_Python.ipynb
@@ -406,9 +406,9 @@
    "outputs": [],
    "source": [
     "# install packages through anaconda prompt\n",
-    "pip3 install tqdm\n",
-    "pip3 install dipy\n",
-    "pip3 install joblib"
+    "!pip3 install tqdm\n",
+    "!pip3 install dipy\n",
+    "!pip3 install joblib"
    ]
   },
   {

--- a/doc/Introduction_to_TF24_IVIM-MRI_CodeCollection_github_and_IVIM_Analysis_using_Python.ipynb
+++ b/doc/Introduction_to_TF24_IVIM-MRI_CodeCollection_github_and_IVIM_Analysis_using_Python.ipynb
@@ -48,16 +48,7 @@
    "execution_count": null,
    "id": "56273b2a",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax (882689640.py, line 2)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;36m  Cell \u001b[1;32mIn[3], line 2\u001b[1;36m\u001b[0m\n\u001b[1;33m    pip3 install numpy\u001b[0m\n\u001b[1;37m         ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# install packages through anaconda prompt\n",
     "!pip3 install numpy\n",


### PR DESCRIPTION

in `Introduction_to_TF24_IVIM-MRI_CodeCollection_github_and_IVIM_Analysis_using_Python.ipynb`

![image](https://github.com/user-attachments/assets/21a2bd25-0769-4f0f-a41f-503a5bf64709)
       
another error happened because of missing `zenodo_get` installation
       
![image](https://github.com/user-attachments/assets/72743f2b-088c-463a-b7a7-d454d191d1f5)

fixing this error by adding `!` before each pip3 to execute well and adding `zenodo_get`

![image](https://github.com/user-attachments/assets/b616df6f-dc76-4bb8-a066-b33756c9c564)

