### PR TITLE
Added a segmented-fitting algorithm based on the recommendation paper

### DIFF
--- a/phantoms/MR_XCAT_qMRI/sim_ivim_sig.py
+++ b/phantoms/MR_XCAT_qMRI/sim_ivim_sig.py
@@ -4,6 +4,10 @@ import nibabel as nib
 import json
 import argparse
 import os
+
+import sys
+sys.path.append('C:/TF_IVIM_OSIPI/TF2.4_IVIM-MRI_CodeCollection')
+
 from utilities.data_simulation.Download_data import download_data
 
 ##########
@@ -19,7 +23,7 @@ def phantom(bvalue, noise, TR=3000, TE=40, motion=False, rician=False, interleav
         states = [1]
     for state in states:
         # Load the .mat file
-        mat_data = loadmat('../../download/Phantoms/XCAT_MAT_RESP/XCAT5D_RP_' + str(state) + '_CP_1.mat')
+        mat_data = loadmat('download/Phantoms/XCAT_MAT_RESP/XCAT5D_RP_' + str(state) + '_CP_1.mat')
 
         # Access the variables in the loaded .mat file
         XCAT = mat_data['IMG']
@@ -429,7 +433,7 @@ if __name__ == '__main__':
     elif args.bvalue:
         bvalues = {"cmd": args.bvalue}
     else:
-        bvalues = parse_bvalues_file("b_values.json") 
+        bvalues = parse_bvalues_file("phantoms\\MR_XCAT_qMRI\\b_values.json")
 
     
     noise = args.noise

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pandas
 sphinx
 sphinx_rtd_theme
 pytest-json-report
+statsmodels

--- a/src/original/TF_reference/segmented_IVIMfit.py
+++ b/src/original/TF_reference/segmented_IVIMfit.py
@@ -1,0 +1,76 @@
+"""
+Code to calculate IVIM maps
+
+Segmented fitting approach
+First fit D using a WLLS
+
+"""
+
+import numpy as np
+import statsmodels.api as sm
+import scipy
+
+def ivim_biexp(bvalues, D, f, Dp, S0=1):
+    return (S0 * (f * np.exp(-bvalues * Dp) + (1 - f) * np.exp(-bvalues * D)))
+
+
+def segmented_IVIM_fit(bvalues, dw_data, b_cutoff = 200, bounds=([0.0001, 0.0, 0.001], [0.004, 0.7, 0.01])):
+    """
+        A segmented fitting implementation for a bi-exponential model.
+        First D is fitted using a mono exponential model on all signal above the bvalue cutoff using an iterative WLLS
+        Then f is fitted by using the b=0 intercept from the mono expontential fit and substracting this from the measured signal at b=0
+        Then D* is fitted using a bi-exponential model with fixed D and f
+
+        """
+    bvalues_D = bvalues[bvalues >= b_cutoff]
+    dw_data_D = dw_data[bvalues >= b_cutoff]
+
+    D, b0_intercept = d_fit_iterative_wls(bvalues_D, np.log(dw_data_D))
+
+    D = D
+    S0 = dw_data[bvalues == 0].item()
+    f = (S0 - b0_intercept) / S0
+
+    Dp = scipy.optimize.least_squares(
+    fun=lambda Dp: ivim_biexp(bvalues, D, f, Dp[0]) - dw_data,
+    x0=D*10,  # Initial guess for D*
+    bounds=(bounds[0][2], bounds[1][2]))
+
+    Dp = Dp.x[0]
+
+    return D, f, Dp
+
+
+def d_fit_iterative_wls(bvalues_D, log_signal, max_iter=100, tolerance= 1e-6):
+    """
+    Function to calculate D using an iterative wlls on the log(signal)
+
+    Parameters:
+    log_signal: the log() of the signal above the threshold for segmented fitting
+
+    bvalues_D: all bvalues above the threshold for fitting D
+
+    max_iter: the maximum number of iterations for WLS
+
+    tolerance: the tolerance for early stopping of the WLS
+    """
+
+    bvals = sm.add_constant(bvalues_D)
+    weights = np.ones_like(log_signal)
+
+    for i in range(max_iter):
+        # Weighted linear regression
+        model = sm.WLS(log_signal, bvals, weights=weights)
+        results = model.fit()
+        signal_pred = results.predict(bvals)
+        residuals = log_signal - signal_pred
+        new_weights = 1 / np.maximum(residuals ** 2, 1e-10)
+
+        if np.linalg.norm(new_weights - weights) < tolerance:
+            break
+        weights = new_weights
+
+    ln_b0_intercept, D_neg  = results.params
+    b0_intercept = np.exp(ln_b0_intercept)
+    D = -D_neg
+    return D, b0_intercept

--- a/src/standardized/TF_reference_IVIMfit.py
+++ b/src/standardized/TF_reference_IVIMfit.py
@@ -1,0 +1,81 @@
+from src.wrappers.OsipiBase import OsipiBase
+from src.original.TF_reference.segmented_IVIMfit import segmented_IVIM_fit
+import numpy as np
+
+class TF_reference_IVIMfit(OsipiBase):
+    """
+    Bi-exponential fitting algorithm by Petra van Houdt and Koen Baas, NKI
+    """
+
+    # I'm thinking that we define default attributes for each submission like this
+    # And in __init__, we can call the OsipiBase control functions to check whether
+    # the user inputs fulfil the requirements
+
+    # Some basic stuff that identifies the algorithm
+    id_author = "OSIPI IVIM TF"
+    id_algorithm_type = "Bi-exponential fit"
+    id_return_parameters = "f, D*, D"
+    id_units = "seconds per milli metre squared or milliseconds per micro metre squared"
+
+    # Algorithm requirements
+    required_bvalues = 4
+    required_thresholds = [0,
+                           1]  # Interval from "at least" to "at most", in case submissions allow a custom number of thresholds
+    required_bounds = False
+    required_bounds_optional = False  # Bounds may not be required but are optional
+    required_initial_guess = False
+    required_initial_guess_optional =False
+    accepted_dimensions = 1  # Not sure how to define this for the number of accepted dimensions. Perhaps like the thresholds, at least and at most?
+
+    # Supported inputs in the standardized class
+    supported_bounds = True # Only bounds for D*
+    supported_initial_guess = False
+    supported_thresholds = True
+
+    def __init__(self, bvalues=None, thresholds=200,bounds=None,initial_guess=None):
+        """
+            Everything this algorithm requires should be implemented here.
+            Number of segmentation thresholds, bounds, etc.
+
+            Our OsipiBase object could contain functions that compare the inputs with
+            the requirements.
+        """
+        super(TF_reference_IVIMfit, self).__init__(bvalues=bvalues, thresholds=thresholds,bounds=bounds,initial_guess=initial_guess)
+        self.TF_reference_algorithm = segmented_IVIM_fit
+        self.initialize(bounds, thresholds)
+
+
+    def initialize(self, bounds, thresholds):
+        if bounds is None:
+            print('warning, no bounds were defined, so default bounds are used of [0, 0, 0.005],[0.005, 1.0, 0.2]')
+            self.bounds=([0, 0, 0.005],[0.005, 1.0, 0.2])
+        else:
+            self.bounds=bounds
+        self.use_bounds = True
+        if thresholds is None:
+            self.thresholds = 200
+            print('warning, no thresholds were defined, so default bounds are used of  522')
+        else:
+            self.thresholds = thresholds
+
+    def ivim_fit(self, signals, bvalues=None):
+        """Perform the IVIM fit
+
+        Args:
+            signals (array-like)
+            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
+
+        Returns:
+            _type_: _description_
+        """
+        #bvalues = np.array(bvalues)
+        bvalues = np.array(bvalues)
+
+        fit_results = self.TF_reference_algorithm(bvalues,signals,b_cutoff=self.thresholds, bounds=self.bounds)
+
+        results = {}
+        results["D"] = fit_results[0]
+        results["f"] = fit_results[1]
+        results["Dp"] = fit_results[2]
+
+        return results

--- a/tests/IVIMmodels/unit_tests/algorithms.json
+++ b/tests/IVIMmodels/unit_tests/algorithms.json
@@ -12,7 +12,8 @@
         "OGC_AmsterdamUMC_biexp",
         "PV_MUMC_biexp",
         "PvH_KB_NKI_IVIMfit",
-        "OJ_GU_seg"
+        "OJ_GU_seg",
+        "TF_reference_IVIMfit"
     ],
     "IAR_LU_biexp": {
         "fail_first_time": true

--- a/tests/IVIMmodels/unit_tests/simple_test_run_of_algorithm.py
+++ b/tests/IVIMmodels/unit_tests/simple_test_run_of_algorithm.py
@@ -12,6 +12,7 @@ from src.standardized.IAR_LU_modified_mix import IAR_LU_modified_mix
 #from src.standardized.PvH_KB_NKI_IVIMfit import PvH_KB_NKI_IVIMfit
 #from src.standardized.PV_MUMC_biexp import PV_MUMC_biexp
 from src.standardized.OGC_AmsterdamUMC_biexp import OGC_AmsterdamUMC_biexp
+from src.standardized.TF_reference_IVIMfit import TF_reference_IVIMfit
 
 ## Simple test code... 
 # Used to just do a test run of an algorithm during development
@@ -37,7 +38,8 @@ def dev_test_run(model, **kwargs):
 #model1 = ETP_SRI_LinearFitting(thresholds=[200])
 #model2 = IAR_LU_biexp(bounds=([0,0,0,0], [1,1,1,1]))
 #model2 = IAR_LU_modified_mix()
-model2 = OGC_AmsterdamUMC_biexp()
+# model2 = OGC_AmsterdamUMC_biexp()
+model2 = TF_reference_IVIMfit()
 
 #dev_test_run(model1)
 dev_test_run(model2)


### PR DESCRIPTION
A segmented fitting algorithm based on the recommendation IVIM paper was added.

The algorithm first fits D using a WLS mono-exponential fit using data of all bvalues above the cutoff value
Then f is estimated from the intercept with b=0 from the mono-exponential fit and the measured signal for b=0
Last D* is estimated from after fixing D and f and fitting the bi-exponential IVIM formula.

In the way it's now coded only bounds for D* are implemented and the initial guess for D* = 10*D

I did do some simple tests and the algorithm seems to work.

### Checklist

- [ ] Self-review of changed code
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides