### PR TITLE
Update xfail logic and test skipping for TCML_TechnionIIT_lsqBOBYQA

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -282,8 +282,8 @@ def bound_input(datafile, algorithms):
         for algorithm in algorithms["algorithms"]:
             algorithm_dict = algorithms.get(algorithm, {})
             if not algorithm_dict.get('deep_learning',False):
-                xfail = {"xfail": name in algorithm_dict.get("xfail_names", {}),
-                    "strict": algorithm_dict.get("xfail_names", {}).get(name, True)}
+                xfail = {"xfail": name in algorithm_dict.get("xfail_names", {}) or "bounds" in algorithm_dict.get("xfail_names", {}),
+                    "strict": algorithm_dict.get("xfail_names", {}).get("bounds", algorithm_dict.get("xfail_names", {}).get(name,True))}
                 kwargs = algorithm_dict.get("options", {})
                 tolerances = algorithm_dict.get("tolerances", {})
                 requires_matlab = algorithm_dict.get("requires_matlab", False)

--- a/tests/IVIMmodels/unit_tests/algorithms.json
+++ b/tests/IVIMmodels/unit_tests/algorithms.json
@@ -28,7 +28,7 @@
         "TF_reference_IVIMfit"
     ],
     "TCML_TechnionIIT_lsqBOBYQA": {
-      "xfail_names": {"pericardium": false}
+      "xfail_names": {"pericardium": false, "bounds": false}
     },
   "IVIM_NEToptim": {
         "deep_learning": true,

--- a/tests/IVIMmodels/unit_tests/skip_tests.md
+++ b/tests/IVIMmodels/unit_tests/skip_tests.md
@@ -1,0 +1,4 @@
+# For TCML_TechnionIIT_lsqBOBYQA we skip 2 tests:
+The pericardium seems to give weird results on some systems. We believe this to be different interpertation of the data and not a systematic error in the algorithm
+For the bounds test, on Mac and Ubuntu, TCML_TechnionIIT_lsqBOBYQA returns default values of 0. We do not believe this to be an intrensic error of the code, but an instable performance in small, unrealistic boundaries. 
+**Consequently, bounds are not tested for TCML_TechnionIIT_lsqBOBYQA and it should be used with caution when bounds are requiered.**

--- a/tests/IVIMmodels/unit_tests/test_ivim_fit.py
+++ b/tests/IVIMmodels/unit_tests/test_ivim_fit.py
@@ -112,8 +112,11 @@ def test_default_bounds_and_initial_guesses(algorithmlist,eng):
         assert 0.9 <= fit.osipi_initial_guess["S0"] <= 1.1, f"For {algorithm}, the default initial guess for S0 {fit.osipi_initial_guess['S0']} is unrealistic; note signal is normalized"
 
 
-def test_bounds(bound_input, eng):
+def test_bounds(bound_input, eng, request):
     name, bvals, data, algorithm, xfail, kwargs, tolerances, requires_matlab = bound_input
+    if xfail["xfail"]:
+        mark = pytest.mark.xfail(reason="xfail", strict=xfail["strict"])
+        request.node.add_marker(mark)
     if requires_matlab:
         if eng is None:
             pytest.skip(reason="Running without matlab; if Matlab is available please run pytest --withmatlab")


### PR DESCRIPTION
Refined xfail handling in conftest.py to account for 'bounds' in xfail_names. Updated algorithms.json to include 'bounds' in xfail_names for TCML_TechnionIIT_lsqBOBYQA. Added skip_tests.md to document skipped tests and reasons. Modified test_ivim_fit.py to dynamically mark tests as xfail based on updated logic.

### Describe the changes you have made in this PR

_A clear and concise description of what you want to happen_

### Link this PR to an issue [optional]

Fixes _#ISSUE-NUMBER_

### Checklist

- [ ] Self-review of changed code
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides