### PR TITLE
fix: replace bare except with except Exception in osipi_fit_full_volume

### DIFF
--- a/src/wrappers/OsipiBase.py
+++ b/src/wrappers/OsipiBase.py
@@ -374,10 +374,12 @@ class OsipiBase:
 
             return results
 
-        except: 
+        except Exception as e:
             # Check if the problem is that full volume fitting is simply not supported in the standardized implementation
             if not hasattr(self, "ivim_fit_full_volume"): #and callable(getattr(self, "ivim_fit_full_volume")):
                 print("Full volume fitting not supported for this algorithm")
+            else:
+                print(f"Full volume fitting failed: {type(e).__name__}: {e}")
 
             return False
 


### PR DESCRIPTION
Hello @oliverchampion 

### Description

This PR fixes Issue #144 by replacing the bare `except:` block in `OsipiBase.osipi_fit_full_volume()` with `except Exception as e:`.

### Changes Made
- Modified `src/wrappers/OsipiBase.py` at line 377 to catch `Exception` instead of all base exceptions.
- Added a diagnostic `print()` statement that outputs the actual error type and message when full volume fitting fails.

### Why is this needed?
1. **Allows graceful termination**: Previously, the bare `except:` was catching `KeyboardInterrupt` and `SystemExit`. This prevented users from using `Ctrl+C` to stop long-running volume fitting operations.
2. **Improves debuggability**: Previously, actual errors (e.g., `ValueError` from bad data shape or algorithm crashes) were silently swallowed, returning `False` with the confusing message `"Full volume fitting not supported for this algorithm"`. Now, actual errors print a helpful diagnostic message, while unsupported algorithms still return `False` quietly with the correct unsupported message.

### Testing/Verification
- ✅ **Sanity Checks Passed**: Ran the full standard test suite (`pytest tests/IVIMmodels/unit_tests/test_ivim_fit.py`). Verified 1127 passed, 167 skipped, 22 xfailed, 6 xpassed. No regressions.
- ✅ **Interrupts Work**: Confirmed that `Ctrl+C` can now cleanly interrupt the process.
- ✅ **Errors Reported**: Confirmed that providing intentionally malformed data shapes now triggers the appropriate diagnostic error output instead of hiding the failure.

*Resolves #144*
