### PR TITLE
fix: add missing D_and_Ds_swap() to 13 algorithms for consistent parameter labelling

### DIFF
--- a/src/standardized/IAR_LU_segmented_3step.py
+++ b/src/standardized/IAR_LU_segmented_3step.py
@@ -114,5 +114,6 @@ class IAR_LU_segmented_3step(OsipiBase):
         results["f"] = fit_results.model_params[1]
         results["Dp"] = fit_results.model_params[2]
         results["D"] = fit_results.model_params[3]
+        results = self.D_and_Ds_swap(results)
         
         return results

--- a/src/standardized/IAR_LU_subtracted.py
+++ b/src/standardized/IAR_LU_subtracted.py
@@ -112,5 +112,6 @@ class IAR_LU_subtracted(OsipiBase):
         results["f"] = fit_results.model_params[1]
         results["Dp"] = fit_results.model_params[2]
         results["D"] = fit_results.model_params[3]
+        results = self.D_and_Ds_swap(results)
         
         return results

--- a/src/standardized/OGC_AmsterdamUMC_Bayesian_biexp.py
+++ b/src/standardized/OGC_AmsterdamUMC_Bayesian_biexp.py
@@ -101,6 +101,7 @@ class OGC_AmsterdamUMC_Bayesian_biexp(OsipiBase):
         results["D"] = fit_results[0]
         results["f"] = fit_results[1]
         results["Dp"] = fit_results[2]
+        results = self.D_and_Ds_swap(results)
 
         return results
 

--- a/src/standardized/OGC_AmsterdamUMC_biexp.py
+++ b/src/standardized/OGC_AmsterdamUMC_biexp.py
@@ -73,5 +73,6 @@ class OGC_AmsterdamUMC_biexp(OsipiBase):
         results["D"] = fit_results[0]
         results["f"] = fit_results[1]
         results["Dp"] = fit_results[2]
+        results = self.D_and_Ds_swap(results)
 
         return results

--- a/src/standardized/OGC_AmsterdamUMC_biexp_segmented.py
+++ b/src/standardized/OGC_AmsterdamUMC_biexp_segmented.py
@@ -79,5 +79,6 @@ class OGC_AmsterdamUMC_biexp_segmented(OsipiBase):
         results["D"] = fit_results[0]
         results["f"] = fit_results[1]
         results["Dp"] = fit_results[2]
+        results = self.D_and_Ds_swap(results)
 
         return results

--- a/src/standardized/OJ_GU_seg.py
+++ b/src/standardized/OJ_GU_seg.py
@@ -76,5 +76,6 @@ class OJ_GU_seg(OsipiBase):
         results["f"] = fit_results['f']
         results["Dp"] = fit_results['Dstar']
         results["D"] = fit_results['D']
+        results = self.D_and_Ds_swap(results)
         
         return results

--- a/src/standardized/PV_MUMC_biexp.py
+++ b/src/standardized/PV_MUMC_biexp.py
@@ -77,5 +77,6 @@ class PV_MUMC_biexp(OsipiBase):
         results["f"] = fit_results[1]
         results["Dp"] = fit_results[2]
         results["D"] = fit_results[0]
+        results = self.D_and_Ds_swap(results)
         
         return results

--- a/src/standardized/PvH_KB_NKI_IVIMfit.py
+++ b/src/standardized/PvH_KB_NKI_IVIMfit.py
@@ -73,5 +73,6 @@ class PvH_KB_NKI_IVIMfit(OsipiBase):
         results["D"] = fit_results[0][0,0,0]/1000
         results["f"] = fit_results[1][0,0,0]
         results["Dp"] = fit_results[2][0,0,0]/1000
+        results = self.D_and_Ds_swap(results)
 
         return results

--- a/src/standardized/TCML_TechnionIIT_SLS.py
+++ b/src/standardized/TCML_TechnionIIT_SLS.py
@@ -92,5 +92,6 @@ class TCML_TechnionIIT_SLS(OsipiBase):
             results["D"] = 0
             results["f"] = 0
             results["Dp"] = 0
+        results = self.D_and_Ds_swap(results)
 
         return results

--- a/src/standardized/TCML_TechnionIIT_lsq_sls_BOBYQA.py
+++ b/src/standardized/TCML_TechnionIIT_lsq_sls_BOBYQA.py
@@ -89,5 +89,6 @@ class TCML_TechnionIIT_lsq_sls_BOBYQA(OsipiBase):
             results["D"] = 0
             results["f"] = 0
             results["Dp"] = 0
+        results = self.D_and_Ds_swap(results)
 
         return results

--- a/src/standardized/TCML_TechnionIIT_lsq_sls_lm.py
+++ b/src/standardized/TCML_TechnionIIT_lsq_sls_lm.py
@@ -91,5 +91,6 @@ class TCML_TechnionIIT_lsq_sls_lm(OsipiBase):
             results["D"] = 0
             results["f"] = 0
             results["Dp"] = 0
+        results = self.D_and_Ds_swap(results)
 
         return results

--- a/src/standardized/TCML_TechnionIIT_lsq_sls_trf.py
+++ b/src/standardized/TCML_TechnionIIT_lsq_sls_trf.py
@@ -92,5 +92,6 @@ class TCML_TechnionIIT_lsq_sls_trf(OsipiBase):
             results["D"] = 0
             results["f"] = 0
             results["Dp"] = 0
+        results = self.D_and_Ds_swap(results)
 
         return results

--- a/src/standardized/TF_reference_IVIMfit.py
+++ b/src/standardized/TF_reference_IVIMfit.py
@@ -82,5 +82,6 @@ class TF_reference_IVIMfit(OsipiBase):
         results["D"] = fit_results[0]
         results["f"] = fit_results[1]
         results["Dp"] = fit_results[2]
+        results = self.D_and_Ds_swap(results)
 
         return results


### PR DESCRIPTION

Add self.D_and_Ds_swap(results) call before return in ivim_fit() for:
- IAR_LU_segmented_3step, IAR_LU_subtracted
- PV_MUMC_biexp
- OGC_AmsterdamUMC_biexp, OGC_AmsterdamUMC_biexp_segmented, OGC_AmsterdamUMC_Bayesian_biexp
- OJ_GU_seg, PvH_KB_NKI_IVIMfit, TF_reference_IVIMfit
- TCML_TechnionIIT_SLS, TCML_TechnionIIT_lsq_sls_lm/trf/BOBYQA

This corrects mislabelled D and D* when the optimizer swaps them. Previously only 9/22 algorithms had this correction.

No regressions: 1127 passed, 167 skipped, 22 xfailed, 6 xpassed.

### Describe the changes you have made in this PR

_A clear and concise description of what you want to happen_

### Link this PR to an issue [optional]

Fixes #146

### Checklist

- [x] Self-review of changed code
- [ ] Added automated tests where applicable
- [ ] Update Docs & Guides