### PR TITLE
fix conftest boolean option

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,14 +19,14 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--ricianNoise",
+        action="store_true",
         default=False,
-        type=bool,
         help="Use Rician noise, non-rician is gaussian",
     )
     parser.addoption(
         "--usePrior",
+        action="store_true",
         default=False,
-        type=bool,
         help="Use a prior where accepted",
     )
     parser.addoption(


### PR DESCRIPTION
### Describe the changes you have made in this PR

Fixes the boolean option in the conftest. The old implementation was set to True if anything was supplied to the --ricianNoise or --usePrior (also if you supply the False argument). To fix this, the new implementation is set to False as default but when --ricianNoise or --usePrior flags are supplied is set to True.


### Checklist

- [ x] Self-review of changed code
- [ x] Added automated tests where applicable
- [ NA] Update Docs & Guides