### PR TITLE
fix: use keyword `bvecs=` in `gradient_table()` calls to suppress dipy deprecation warning

### DIFF
--- a/src/standardized/IAR_LU_biexp.py
+++ b/src/standardized/IAR_LU_biexp.py
@@ -59,7 +59,7 @@ class IAR_LU_biexp(OsipiBase):
         if self.bvalues is not None:
             bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(self.bvalues, bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
             
             self.IAR_algorithm = IvimModelBiExp(gtab, bounds=self.bounds, initial_guess=self.initial_guess)
         else:

--- a/src/standardized/IAR_LU_modified_mix.py
+++ b/src/standardized/IAR_LU_modified_mix.py
@@ -58,7 +58,7 @@ class IAR_LU_modified_mix(OsipiBase):
         if self.bvalues is not None:
             bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(self.bvalues, bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
             
             bounds = [[self.bounds["f"][0], self.bounds["Dp"][0]*1000, self.bounds["D"][0]*1000], 
                       [self.bounds["f"][1], self.bounds["Dp"][1]*1000, self.bounds["D"][1]*1000]]
@@ -90,7 +90,7 @@ class IAR_LU_modified_mix(OsipiBase):
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(bvalues, bvec, b0_threshold=0)
+            gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
             
             self.IAR_algorithm = IvimModelVP(gtab, bounds=bounds, rescale_results_to_mm2_s=True)
 

--- a/src/standardized/IAR_LU_modified_topopro.py
+++ b/src/standardized/IAR_LU_modified_topopro.py
@@ -61,7 +61,7 @@ class IAR_LU_modified_topopro(OsipiBase):
         if self.bvalues is not None:
             bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(self.bvalues, bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
 
             bounds = [[self.bounds["f"][0], self.bounds["Dp"][0]*1000, self.bounds["D"][0]*1000], 
                            [self.bounds["f"][1], self.bounds["Dp"][1]*1000, self.bounds["D"][1]*1000]]
@@ -92,7 +92,7 @@ class IAR_LU_modified_topopro(OsipiBase):
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(bvalues, bvec, b0_threshold=0)
+            gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
             
             self.IAR_algorithm = IvimModelTopoPro(gtab, bounds=bounds, rescale_results_to_mm2_s=True)
             

--- a/src/standardized/IAR_LU_segmented_2step.py
+++ b/src/standardized/IAR_LU_segmented_2step.py
@@ -60,7 +60,7 @@ class IAR_LU_segmented_2step(OsipiBase):
         if self.bvalues is not None:
             bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(self.bvalues, bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
             bounds = [[self.bounds["S0"][0], self.bounds["f"][0], self.bounds["Dp"][0], self.bounds["D"][0]], \
                       [self.bounds["S0"][1], self.bounds["f"][1], self.bounds["Dp"][1], self.bounds["D"][1]]]
         
@@ -97,7 +97,7 @@ class IAR_LU_segmented_2step(OsipiBase):
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(bvalues, bvec, b0_threshold=0)
+            gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
 
             if self.thresholds is None:
                 self.thresholds = 200

--- a/src/standardized/IAR_LU_segmented_3step.py
+++ b/src/standardized/IAR_LU_segmented_3step.py
@@ -60,7 +60,7 @@ class IAR_LU_segmented_3step(OsipiBase):
         if self.bvalues is not None:
             bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(self.bvalues, bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
 
             # Adapt the bounds to the format needed for the algorithm
             bounds = [[self.bounds["S0"][0], self.bounds["f"][0], self.bounds["Dp"][0], self.bounds["D"][0]], \
@@ -99,7 +99,7 @@ class IAR_LU_segmented_3step(OsipiBase):
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(bvalues, bvec, b0_threshold=0)
+            gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
             
             self.IAR_algorithm = IvimModelSegmented3Step(gtab, bounds=bounds, initial_guess=initial_guess)
             

--- a/src/standardized/IAR_LU_subtracted.py
+++ b/src/standardized/IAR_LU_subtracted.py
@@ -58,7 +58,7 @@ class IAR_LU_subtracted(OsipiBase):
         if self.bvalues is not None:
             bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(self.bvalues, bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
 
             # Adapt the bounds to the format needed for the algorithm
             bounds = [[self.bounds["S0"][0], self.bounds["f"][0], self.bounds["Dp"][0], self.bounds["D"][0]], \
@@ -97,7 +97,7 @@ class IAR_LU_subtracted(OsipiBase):
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(bvalues, bvec, b0_threshold=0)
+            gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
             
             self.IAR_algorithm = IvimModelSubtracted(gtab, bounds=bounds, initial_guess=initial_guess)
             


### PR DESCRIPTION
This PR fixes a dipy deprecation warning in all 6 IAR_LU_ algorithms by converting bvec from a positional argument to the keyword form bvecs=bvec when calling gradient_table().

dipy 1.11.0 emits the following deprecation warning when `bvec` is passed positionally:

```
UserWarning: Pass ['bvecs'] as keyword args.
From version 2.0.0 passing these as positional arguments will result in an error.
```

This will become a hard error in dipy 2.0.0, breaking all 6 IAR_LU algorithms.

Changed **11 call sites** across **6 files** from:
```python
gtab = gradient_table(self.bvalues, bvec, b0_threshold=0)
```
to:
```python
gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
```
### Files Changed

| File | Lines Changed | Location |
|---|---|---|
| `IAR_LU_biexp.py` | Line 62 | `__init__` (2 other sites were already fixed) |
| `IAR_LU_modified_mix.py` | Lines 61, 93 | `__init__` and `ivim_fit` |
| `IAR_LU_modified_topopro.py` | Lines 64, 95 | `__init__` and `ivim_fit` |
| `IAR_LU_segmented_2step.py` | Lines 63, 100 | `__init__` and `ivim_fit` |
| `IAR_LU_segmented_3step.py` | Lines 63, 102 | `__init__` and `ivim_fit` |
| `IAR_LU_subtracted.py` | Lines 61, 100 | `__init__` and `ivim_fit` |

### Testing

- All 622 existing `test_ivim_fit_saved` tests pass (89 skipped, 11 xfailed, 4 xpassed).
- Verified using a reproduction script (`bug_2/reproduce_dipy_warning.py`) that the warning is no longer emitted after the fix.
- This is a non-breaking change — using the keyword argument produces identical behavior to positional; it only suppresses the deprecation warning and ensures forward compatibility with dipy 2.0.0.

Fixes #156 