### PR TITLE
centralize b-value management at initialization (#155)

### DIFF
--- a/WrapImage/nifti_wrapper.py
+++ b/WrapImage/nifti_wrapper.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
 
         # Pass additional arguments to the algorithm
 
-        fit = OsipiBase(algorithm=args.algorithm)
+        fit = OsipiBase(algorithm=args.algorithm, bvalues=bvals)
         f_image = []
         Dp_image = []
         D_image = []
@@ -109,7 +109,7 @@ if __name__ == "__main__":
         n = data.ndim
         total_iteration = np.prod(data.shape[:n-1])
         for idx, view in tqdm(loop_over_first_n_minus_1_dimensions(data), desc=f"{args.algorithm} is fitting", dynamic_ncols=True, total=total_iteration):
-            fit_result = fit.osipi_fit(view, bvals)
+            fit_result = fit.osipi_fit(view)
             f_image.append(fit_result["f"])
             Dp_image.append(fit_result["Dp"])
             D_image.append(fit_result["D"])

--- a/WrapImage/nifti_wrapper_kaapana.py
+++ b/WrapImage/nifti_wrapper_kaapana.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
         affine = np.array(affine_override).reshape(4, 4)
 
     # Initialize model
-    fit = OsipiBase(algorithm=algorithm)
+    fit = OsipiBase(algorithm=algorithm, bvalues=bvals)
 
     # Preallocate output arrays
     shape = data.shape[:data.ndim - 1]
@@ -142,7 +142,7 @@ if __name__ == "__main__":
         loop_over_first_n_minus_1_dimensions(data),
         desc="Fitting IVIM model", dynamic_ncols=True, total=total_iteration
     ):
-        fit_result = fit.osipi_fit(view, bvals)
+        fit_result = fit.osipi_fit(view)
         f_image[idx] = fit_result["f"]
         Dp_image[idx] = fit_result["Dp"]
         D_image[idx] = fit_result["D"]

--- a/src/standardized/ASD_MemorialSloanKettering_QAMPER_IVIM.py
+++ b/src/standardized/ASD_MemorialSloanKettering_QAMPER_IVIM.py
@@ -80,11 +80,10 @@ class ASD_MemorialSloanKettering_QAMPER_IVIM(OsipiBase):
 
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
-        bvalues=self.bvalues
         LB = np.array(bounds[0])[[1,0,2,3]]
         UB = np.array(bounds[1])[[1,0,2,3]]
 
-        fit_results = self.algorithm(np.array(signals)[:,np.newaxis], bvalues, LB, UB, np.array(initial_guess)[[1,0,2,3]])
+        fit_results = self.algorithm(np.array(signals)[:,np.newaxis], self.bvalues, LB, UB, np.array(initial_guess)[[1,0,2,3]])
 
         results = {}
         results["D"] = fit_results[0]

--- a/src/standardized/ASD_MemorialSloanKettering_QAMPER_IVIM.py
+++ b/src/standardized/ASD_MemorialSloanKettering_QAMPER_IVIM.py
@@ -80,7 +80,7 @@ class ASD_MemorialSloanKettering_QAMPER_IVIM(OsipiBase):
 
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
-        bvalues=np.array(self.bvalues)
+        bvalues=self.bvalues
         LB = np.array(bounds[0])[[1,0,2,3]]
         UB = np.array(bounds[1])[[1,0,2,3]]
 

--- a/src/standardized/ASD_MemorialSloanKettering_QAMPER_IVIM.py
+++ b/src/standardized/ASD_MemorialSloanKettering_QAMPER_IVIM.py
@@ -66,12 +66,11 @@ class ASD_MemorialSloanKettering_QAMPER_IVIM(OsipiBase):
         (f_arr, D_arr, Dx_arr, s0_arr, fitted_dwi_arr, RSS, rms_val, chi, AIC, BIC, R_sq) = results
         return D_arr/1000, f_arr, Dx_arr/1000, s0_arr
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -81,7 +80,7 @@ class ASD_MemorialSloanKettering_QAMPER_IVIM(OsipiBase):
 
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
-        bvalues=np.array(bvalues)
+        bvalues=np.array(self.bvalues)
         LB = np.array(bounds[0])[[1,0,2,3]]
         UB = np.array(bounds[1])[[1,0,2,3]]
 

--- a/src/standardized/DT_IIITN_WLS.py
+++ b/src/standardized/DT_IIITN_WLS.py
@@ -66,17 +66,16 @@ class DT_IIITN_WLS(OsipiBase):
         )
         self.method = method.upper()
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit using the selected method (WLS or RLM).
 
         Args:
             signals (array-like): Signal intensities at each b-value.
-            bvalues (array-like, optional): b-values for the signals.
 
         Returns:
             dict: Dictionary with keys "D", "f", "Dp".
         """
-        bvalues = np.array(bvalues)
+        bvalues = np.array(self.bvalues)
 
         # Use threshold as cutoff if available
         cutoff = 200

--- a/src/standardized/DT_IIITN_WLS.py
+++ b/src/standardized/DT_IIITN_WLS.py
@@ -75,7 +75,7 @@ class DT_IIITN_WLS(OsipiBase):
         Returns:
             dict: Dictionary with keys "D", "f", "Dp".
         """
-        bvalues = np.array(self.bvalues)
+        bvalues = self.bvalues
 
         # Use threshold as cutoff if available
         cutoff = 200

--- a/src/standardized/DT_IIITN_WLS.py
+++ b/src/standardized/DT_IIITN_WLS.py
@@ -75,14 +75,12 @@ class DT_IIITN_WLS(OsipiBase):
         Returns:
             dict: Dictionary with keys "D", "f", "Dp".
         """
-        bvalues = self.bvalues
-
         # Use threshold as cutoff if available
         cutoff = 200
         if self.thresholds is not None and len(self.thresholds) > 0:
             cutoff = self.thresholds[0]
 
-        D, f, Dp = wls_ivim_fit(bvalues, signals, cutoff=cutoff,
+        D, f, Dp = wls_ivim_fit(self.bvalues, signals, cutoff=cutoff,
                                 method=self.method)
 
         results = {}

--- a/src/standardized/ETP_SRI_LinearFitting.py
+++ b/src/standardized/ETP_SRI_LinearFitting.py
@@ -59,20 +59,18 @@ class ETP_SRI_LinearFitting(OsipiBase):
         # Check the inputs
         
     
-    def ivim_fit(self, signals, bvalues=None, linear_fit_option=False, **kwargs):
+    def ivim_fit(self, signals, linear_fit_option=False, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
             linear_fit_option (bool, optional): This fit has an option to only run a linear fit. Defaults to False.
 
         Returns:
             _type_: _description_
         """
         signals[signals<0.0000001]=0.0000001
-        if bvalues is None:
-            bvalues = self.bvalues
+        bvalues = self.bvalues
         
         if self.thresholds is None:
             ETP_object = LinearFit()

--- a/src/standardized/ETP_SRI_LinearFitting.py
+++ b/src/standardized/ETP_SRI_LinearFitting.py
@@ -70,7 +70,6 @@ class ETP_SRI_LinearFitting(OsipiBase):
             _type_: _description_
         """
         signals[signals<0.0000001]=0.0000001
-        bvalues = self.bvalues
         
         if self.thresholds is None:
             ETP_object = LinearFit()
@@ -79,14 +78,14 @@ class ETP_SRI_LinearFitting(OsipiBase):
         
         results = {}
         if linear_fit_option:
-            f, Dstar = ETP_object.linear_fit(bvalues, signals, self.ETP_weighting, self.ETP_stats)
+            f, Dstar = ETP_object.linear_fit(self.bvalues, signals, self.ETP_weighting, self.ETP_stats)
 
             results["f"] = f
             results["Dp"] = Dstar
 
             return results
         else: 
-            f, D, Dstar = ETP_object.ivim_fit(bvalues, signals)
+            f, D, Dstar = ETP_object.ivim_fit(self.bvalues, signals)
 
             results["f"] = f
             results["Dp"] = Dstar

--- a/src/standardized/IAR_LU_biexp.py
+++ b/src/standardized/IAR_LU_biexp.py
@@ -71,12 +71,11 @@ class IAR_LU_biexp(OsipiBase):
             self.IAR_algorithm = None
         
     
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -88,10 +87,7 @@ class IAR_LU_biexp(OsipiBase):
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         
         if self.IAR_algorithm is None:
-            if bvalues is None:
-                bvalues = self.bvalues
-            else:
-                bvalues = np.asarray(bvalues)
+            bvalues = np.asarray(self.bvalues)
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1
@@ -110,12 +106,11 @@ class IAR_LU_biexp(OsipiBase):
         return results
 
 
-    def ivim_fit_full_volume(self, signals, bvalues, **kwargs):
+    def ivim_fit_full_volume(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -125,16 +120,14 @@ class IAR_LU_biexp(OsipiBase):
                        [self.bounds["S0"][1], self.bounds["f"][1], self.bounds["Dp"][1], self.bounds["D"][1]]]
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         if self.IAR_algorithm is None:
-            if bvalues is None:
-                bvalues = self.bvalues
-            else:
-                bvalues = np.asarray(bvalues)
+            bvalues = np.asarray(self.bvalues)
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1
             gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
             
             self.IAR_algorithm = IvimModelBiExp(gtab, bounds=bounds, initial_guess=initial_guess)
+        bvalues = np.asarray(self.bvalues)
         b0_index = np.where(bvalues == 0)[0][0]
         mask = signals[...,b0_index]>0
         fit_results = self.IAR_algorithm.fit(signals, mask=mask)

--- a/src/standardized/IAR_LU_biexp.py
+++ b/src/standardized/IAR_LU_biexp.py
@@ -87,11 +87,10 @@ class IAR_LU_biexp(OsipiBase):
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         
         if self.IAR_algorithm is None:
-            bvalues = self.bvalues
             
-            bvec = np.zeros((bvalues.size, 3))
+            bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
             
             self.IAR_algorithm = IvimModelBiExp(gtab, bounds=bounds, initial_guess=initial_guess)
             
@@ -120,15 +119,13 @@ class IAR_LU_biexp(OsipiBase):
                        [self.bounds["S0"][1], self.bounds["f"][1], self.bounds["Dp"][1], self.bounds["D"][1]]]
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         if self.IAR_algorithm is None:
-            bvalues = self.bvalues
             
-            bvec = np.zeros((bvalues.size, 3))
+            bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
             
             self.IAR_algorithm = IvimModelBiExp(gtab, bounds=bounds, initial_guess=initial_guess)
-        bvalues = self.bvalues
-        b0_index = np.where(bvalues == 0)[0][0]
+        b0_index = np.where(self.bvalues == 0)[0][0]
         mask = signals[...,b0_index]>0
         fit_results = self.IAR_algorithm.fit(signals, mask=mask)
         

--- a/src/standardized/IAR_LU_biexp.py
+++ b/src/standardized/IAR_LU_biexp.py
@@ -87,7 +87,7 @@ class IAR_LU_biexp(OsipiBase):
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         
         if self.IAR_algorithm is None:
-            bvalues = np.asarray(self.bvalues)
+            bvalues = self.bvalues
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1
@@ -120,14 +120,14 @@ class IAR_LU_biexp(OsipiBase):
                        [self.bounds["S0"][1], self.bounds["f"][1], self.bounds["Dp"][1], self.bounds["D"][1]]]
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         if self.IAR_algorithm is None:
-            bvalues = np.asarray(self.bvalues)
+            bvalues = self.bvalues
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1
             gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
             
             self.IAR_algorithm = IvimModelBiExp(gtab, bounds=bounds, initial_guess=initial_guess)
-        bvalues = np.asarray(self.bvalues)
+        bvalues = self.bvalues
         b0_index = np.where(bvalues == 0)[0][0]
         mask = signals[...,b0_index]>0
         fit_results = self.IAR_algorithm.fit(signals, mask=mask)

--- a/src/standardized/IAR_LU_modified_mix.py
+++ b/src/standardized/IAR_LU_modified_mix.py
@@ -82,7 +82,7 @@ class IAR_LU_modified_mix(OsipiBase):
                   [self.bounds["f"][1], self.bounds["Dp"][1]*1000, self.bounds["D"][1]*1000]]
         
         if self.IAR_algorithm is None:
-            bvalues = np.asarray(self.bvalues)
+            bvalues = self.bvalues
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1

--- a/src/standardized/IAR_LU_modified_mix.py
+++ b/src/standardized/IAR_LU_modified_mix.py
@@ -68,12 +68,11 @@ class IAR_LU_modified_mix(OsipiBase):
             self.IAR_algorithm = None
         
     
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -83,10 +82,7 @@ class IAR_LU_modified_mix(OsipiBase):
                   [self.bounds["f"][1], self.bounds["Dp"][1]*1000, self.bounds["D"][1]*1000]]
         
         if self.IAR_algorithm is None:
-            if bvalues is None:
-                bvalues = self.bvalues
-            else:
-                bvalues = np.asarray(bvalues)
+            bvalues = np.asarray(self.bvalues)
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1

--- a/src/standardized/IAR_LU_modified_mix.py
+++ b/src/standardized/IAR_LU_modified_mix.py
@@ -82,11 +82,10 @@ class IAR_LU_modified_mix(OsipiBase):
                   [self.bounds["f"][1], self.bounds["Dp"][1]*1000, self.bounds["D"][1]*1000]]
         
         if self.IAR_algorithm is None:
-            bvalues = self.bvalues
             
-            bvec = np.zeros((bvalues.size, 3))
+            bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
             
             self.IAR_algorithm = IvimModelVP(gtab, bounds=bounds, rescale_results_to_mm2_s=True)
 

--- a/src/standardized/IAR_LU_modified_topopro.py
+++ b/src/standardized/IAR_LU_modified_topopro.py
@@ -85,11 +85,10 @@ class IAR_LU_modified_topopro(OsipiBase):
                   [self.bounds["f"][1], self.bounds["Dp"][1]*1000, self.bounds["D"][1]*1000]]
         
         if self.IAR_algorithm is None:
-            bvalues = self.bvalues
             
-            bvec = np.zeros((bvalues.size, 3))
+            bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
             
             self.IAR_algorithm = IvimModelTopoPro(gtab, bounds=bounds, rescale_results_to_mm2_s=True)
             

--- a/src/standardized/IAR_LU_modified_topopro.py
+++ b/src/standardized/IAR_LU_modified_topopro.py
@@ -85,7 +85,7 @@ class IAR_LU_modified_topopro(OsipiBase):
                   [self.bounds["f"][1], self.bounds["Dp"][1]*1000, self.bounds["D"][1]*1000]]
         
         if self.IAR_algorithm is None:
-            bvalues = np.asarray(self.bvalues)
+            bvalues = self.bvalues
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1

--- a/src/standardized/IAR_LU_modified_topopro.py
+++ b/src/standardized/IAR_LU_modified_topopro.py
@@ -72,12 +72,11 @@ class IAR_LU_modified_topopro(OsipiBase):
             self.IAR_algorithm = None
         
     
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -86,10 +85,7 @@ class IAR_LU_modified_topopro(OsipiBase):
                   [self.bounds["f"][1], self.bounds["Dp"][1]*1000, self.bounds["D"][1]*1000]]
         
         if self.IAR_algorithm is None:
-            if bvalues is None:
-                bvalues = self.bvalues
-            else:
-                bvalues = np.asarray(bvalues)
+            bvalues = np.asarray(self.bvalues)
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1

--- a/src/standardized/IAR_LU_segmented_2step.py
+++ b/src/standardized/IAR_LU_segmented_2step.py
@@ -72,12 +72,11 @@ class IAR_LU_segmented_2step(OsipiBase):
             self.IAR_algorithm = None
         
     
-    def ivim_fit(self, signals, bvalues, thresholds=None, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -90,10 +89,7 @@ class IAR_LU_segmented_2step(OsipiBase):
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         
         if self.IAR_algorithm is None:
-            if bvalues is None:
-                bvalues = self.bvalues
-            else:
-                bvalues = np.asarray(bvalues)
+            bvalues = np.asarray(self.bvalues)
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1

--- a/src/standardized/IAR_LU_segmented_2step.py
+++ b/src/standardized/IAR_LU_segmented_2step.py
@@ -89,11 +89,10 @@ class IAR_LU_segmented_2step(OsipiBase):
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         
         if self.IAR_algorithm is None:
-            bvalues = self.bvalues
             
-            bvec = np.zeros((bvalues.size, 3))
+            bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
 
             if self.thresholds is None:
                 self.thresholds = 200

--- a/src/standardized/IAR_LU_segmented_2step.py
+++ b/src/standardized/IAR_LU_segmented_2step.py
@@ -89,7 +89,7 @@ class IAR_LU_segmented_2step(OsipiBase):
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         
         if self.IAR_algorithm is None:
-            bvalues = np.asarray(self.bvalues)
+            bvalues = self.bvalues
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1

--- a/src/standardized/IAR_LU_segmented_3step.py
+++ b/src/standardized/IAR_LU_segmented_3step.py
@@ -92,11 +92,10 @@ class IAR_LU_segmented_3step(OsipiBase):
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         
         if self.IAR_algorithm is None:
-            bvalues = self.bvalues
             
-            bvec = np.zeros((bvalues.size, 3))
+            bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
 
             self.IAR_algorithm = IvimModelSegmented3Step(gtab, bounds=bounds, initial_guess=initial_guess)
             

--- a/src/standardized/IAR_LU_segmented_3step.py
+++ b/src/standardized/IAR_LU_segmented_3step.py
@@ -75,12 +75,11 @@ class IAR_LU_segmented_3step(OsipiBase):
             self.IAR_algorithm = None
         
     
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -93,10 +92,7 @@ class IAR_LU_segmented_3step(OsipiBase):
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         
         if self.IAR_algorithm is None:
-            if bvalues is None:
-                bvalues = self.bvalues
-            else:
-                bvalues = np.asarray(bvalues)
+            bvalues = np.asarray(self.bvalues)
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1

--- a/src/standardized/IAR_LU_segmented_3step.py
+++ b/src/standardized/IAR_LU_segmented_3step.py
@@ -92,7 +92,7 @@ class IAR_LU_segmented_3step(OsipiBase):
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         
         if self.IAR_algorithm is None:
-            bvalues = np.asarray(self.bvalues)
+            bvalues = self.bvalues
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1

--- a/src/standardized/IAR_LU_subtracted.py
+++ b/src/standardized/IAR_LU_subtracted.py
@@ -72,12 +72,11 @@ class IAR_LU_subtracted(OsipiBase):
             self.IAR_algorithm = None
         
     
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -90,10 +89,7 @@ class IAR_LU_subtracted(OsipiBase):
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         
         if self.IAR_algorithm is None:
-            if bvalues is None:
-                bvalues = self.bvalues
-            else:
-                bvalues = np.asarray(bvalues)
+            bvalues = np.asarray(self.bvalues)
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1

--- a/src/standardized/IAR_LU_subtracted.py
+++ b/src/standardized/IAR_LU_subtracted.py
@@ -89,11 +89,10 @@ class IAR_LU_subtracted(OsipiBase):
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         
         if self.IAR_algorithm is None:
-            bvalues = self.bvalues
             
-            bvec = np.zeros((bvalues.size, 3))
+            bvec = np.zeros((self.bvalues.size, 3))
             bvec[:,2] = 1
-            gtab = gradient_table(bvalues, bvecs=bvec, b0_threshold=0)
+            gtab = gradient_table(self.bvalues, bvecs=bvec, b0_threshold=0)
 
             self.IAR_algorithm = IvimModelSubtracted(gtab, bounds=bounds, initial_guess=initial_guess)
             

--- a/src/standardized/IAR_LU_subtracted.py
+++ b/src/standardized/IAR_LU_subtracted.py
@@ -89,7 +89,7 @@ class IAR_LU_subtracted(OsipiBase):
         initial_guess = [self.initial_guess["S0"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["D"]]
         
         if self.IAR_algorithm is None:
-            bvalues = np.asarray(self.bvalues)
+            bvalues = self.bvalues
             
             bvec = np.zeros((bvalues.size, 3))
             bvec[:,2] = 1

--- a/src/standardized/IVIM_NEToptim.py
+++ b/src/standardized/IVIM_NEToptim.py
@@ -89,18 +89,15 @@ class IVIM_NEToptim(OsipiBase):
         self.algorithm =lambda data: deep.predict_IVIM(data, self.bvalues, self.net, self.arg)
 
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
         """
-        if not np.array_equal(bvalues, self.bvalues):
-            raise ValueError("bvalue list at fitting must be identical as the one at initiation, otherwise it will not run")
 
         paramsNN = deep.predict_IVIM(signals, self.bvalues, self.net, self.arg)
 
@@ -112,18 +109,15 @@ class IVIM_NEToptim(OsipiBase):
         return results
 
 
-    def ivim_fit_full_volume(self, signals, bvalues, retrain_on_input_data=False, **kwargs):
+    def ivim_fit_full_volume(self, signals, retrain_on_input_data=False, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
         """
-        if not np.array_equal(bvalues, self.bvalues):
-            raise ValueError("bvalue list at fitting must be identical as the one at initiation, otherwise it will not run")
         minimum_bvalue = np.min(self.bvalues) # We normalize the signal to the minimum bvalue. Should be 0 or very close to 0.
         b0_indices = np.where(self.bvalues == minimum_bvalue)[0]
         normalization_factor = np.mean(signals[..., b0_indices],axis=-1)

--- a/src/standardized/OGC_AmsterdamUMC_Bayesian_biexp.py
+++ b/src/standardized/OGC_AmsterdamUMC_Bayesian_biexp.py
@@ -87,15 +87,13 @@ class OGC_AmsterdamUMC_Bayesian_biexp(OsipiBase):
 
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
-        bvalues=self.bvalues
-
         epsilon = 0.000001
-        fit_results = fit_segmented(bvalues, signals, bounds=bounds, cutoff=self.thresholds, p0=initial_guess)
+        fit_results = fit_segmented(self.bvalues, signals, bounds=bounds, cutoff=self.thresholds, p0=initial_guess)
         fit_results=np.array(fit_results+(1,))
         for i in range(4):
             if fit_results[i] < bounds[0][i] : fit_results[0] = bounds[0][i]+epsilon
             if fit_results[i] > bounds[1][i] : fit_results[0] = bounds[1][i]-epsilon
-        fit_results = self.OGC_algorithm(bvalues, signals, self.neg_log_prior, x0=fit_results, fitS0=self.fitS0, bounds=bounds)
+        fit_results = self.OGC_algorithm(self.bvalues, signals, self.neg_log_prior, x0=fit_results, fitS0=self.fitS0, bounds=bounds)
 
         results = {}
         results["D"] = fit_results[0]
@@ -120,22 +118,19 @@ class OGC_AmsterdamUMC_Bayesian_biexp(OsipiBase):
         # Get index of b=0
         shape=np.shape(signals)
 
-        bvalues=self.bvalues
-        b0_index = np.where(bvalues == 0)[0][0]
+        b0_index = np.where(self.bvalues == 0)[0][0]
         # Mask of voxels where signal at b=0 >= 0.5
         valid_mask = signals[..., b0_index] >= 0
         # Select only valid voxels for fitting
         signals = signals[valid_mask]
 
-        minimum_bvalue = np.min(bvalues) # We normalize the signal to the minimum bvalue. Should be 0 or very close to 0.
-        b0_indices = np.where(bvalues == minimum_bvalue)[0]
+        minimum_bvalue = np.min(self.bvalues) # We normalize the signal to the minimum bvalue. Should be 0 or very close to 0.
+        b0_indices = np.where(self.bvalues == minimum_bvalue)[0]
         normalization_factor = np.mean(signals[..., b0_indices],axis=-1)
         signals = signals / np.repeat(normalization_factor[...,np.newaxis],np.shape(signals)[-1],-1)
 
-        bvalues=self.bvalues
-
         epsilon = 0.000001
-        fit_results = np.array(fit_segmented_array(bvalues, signals, bounds=bounds, cutoff=self.thresholds, p0=initial_guess))
+        fit_results = np.array(fit_segmented_array(self.bvalues, signals, bounds=bounds, cutoff=self.thresholds, p0=initial_guess))
         #fit_results=np.array(fit_results+(1,))
         # Loop over parameters (rows)
 
@@ -149,7 +144,7 @@ class OGC_AmsterdamUMC_Bayesian_biexp(OsipiBase):
                 fit_results[i, below] = bounds[0][i] + epsilon
                 fit_results[i, above] = bounds[1][i] - epsilon
         self.jobs=njobs
-        fit_results = self.OGC_algorithm_array(bvalues, signals,fit_results, self)
+        fit_results = self.OGC_algorithm_array(self.bvalues, signals,fit_results, self)
 
         D=np.zeros(shape[0:-1])
         D[valid_mask]=fit_results[0]

--- a/src/standardized/OGC_AmsterdamUMC_Bayesian_biexp.py
+++ b/src/standardized/OGC_AmsterdamUMC_Bayesian_biexp.py
@@ -73,12 +73,11 @@ class OGC_AmsterdamUMC_Bayesian_biexp(OsipiBase):
                 self.neg_log_prior = empirical_neg_log_prior(prior_in[0], prior_in[1], prior_in[2])
         self.fitS0=fitS0
 
-    def ivim_fit(self, signals, bvalues, initial_guess=None, **kwargs):
+    def ivim_fit(self, signals, initial_guess=None, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -88,7 +87,7 @@ class OGC_AmsterdamUMC_Bayesian_biexp(OsipiBase):
 
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
-        bvalues=np.array(bvalues)
+        bvalues=np.array(self.bvalues)
 
         epsilon = 0.000001
         fit_results = fit_segmented(bvalues, signals, bounds=bounds, cutoff=self.thresholds, p0=initial_guess)
@@ -105,11 +104,10 @@ class OGC_AmsterdamUMC_Bayesian_biexp(OsipiBase):
 
         return results
 
-    def ivim_fit_full_volume(self, signals, bvalues, njobs=4, **kwargs):
+    def ivim_fit_full_volume(self, signals, njobs=4, **kwargs):
         """Perform the IVIM fit
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
         Returns:
             _type_: _description_
         """
@@ -122,6 +120,7 @@ class OGC_AmsterdamUMC_Bayesian_biexp(OsipiBase):
         # Get index of b=0
         shape=np.shape(signals)
 
+        bvalues=np.array(self.bvalues)
         b0_index = np.where(bvalues == 0)[0][0]
         # Mask of voxels where signal at b=0 >= 0.5
         valid_mask = signals[..., b0_index] >= 0
@@ -133,7 +132,7 @@ class OGC_AmsterdamUMC_Bayesian_biexp(OsipiBase):
         normalization_factor = np.mean(signals[..., b0_indices],axis=-1)
         signals = signals / np.repeat(normalization_factor[...,np.newaxis],np.shape(signals)[-1],-1)
 
-        bvalues=np.array(bvalues)
+        bvalues=np.array(self.bvalues)
 
         epsilon = 0.000001
         fit_results = np.array(fit_segmented_array(bvalues, signals, bounds=bounds, cutoff=self.thresholds, p0=initial_guess))

--- a/src/standardized/OGC_AmsterdamUMC_Bayesian_biexp.py
+++ b/src/standardized/OGC_AmsterdamUMC_Bayesian_biexp.py
@@ -87,7 +87,7 @@ class OGC_AmsterdamUMC_Bayesian_biexp(OsipiBase):
 
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
-        bvalues=np.array(self.bvalues)
+        bvalues=self.bvalues
 
         epsilon = 0.000001
         fit_results = fit_segmented(bvalues, signals, bounds=bounds, cutoff=self.thresholds, p0=initial_guess)
@@ -120,7 +120,7 @@ class OGC_AmsterdamUMC_Bayesian_biexp(OsipiBase):
         # Get index of b=0
         shape=np.shape(signals)
 
-        bvalues=np.array(self.bvalues)
+        bvalues=self.bvalues
         b0_index = np.where(bvalues == 0)[0][0]
         # Mask of voxels where signal at b=0 >= 0.5
         valid_mask = signals[..., b0_index] >= 0
@@ -132,7 +132,7 @@ class OGC_AmsterdamUMC_Bayesian_biexp(OsipiBase):
         normalization_factor = np.mean(signals[..., b0_indices],axis=-1)
         signals = signals / np.repeat(normalization_factor[...,np.newaxis],np.shape(signals)[-1],-1)
 
-        bvalues=np.array(self.bvalues)
+        bvalues=self.bvalues
 
         epsilon = 0.000001
         fit_results = np.array(fit_segmented_array(bvalues, signals, bounds=bounds, cutoff=self.thresholds, p0=initial_guess))

--- a/src/standardized/OGC_AmsterdamUMC_biexp.py
+++ b/src/standardized/OGC_AmsterdamUMC_biexp.py
@@ -65,8 +65,7 @@ class OGC_AmsterdamUMC_biexp(OsipiBase):
 
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
-        bvalues=self.bvalues
-        fit_results = self.OGC_algorithm(bvalues, signals, p0=initial_guess, bounds=bounds, fitS0=self.fitS0)
+        fit_results = self.OGC_algorithm(self.bvalues, signals, p0=initial_guess, bounds=bounds, fitS0=self.fitS0)
 
         results = {}
         results["D"] = fit_results[0]

--- a/src/standardized/OGC_AmsterdamUMC_biexp.py
+++ b/src/standardized/OGC_AmsterdamUMC_biexp.py
@@ -65,7 +65,7 @@ class OGC_AmsterdamUMC_biexp(OsipiBase):
 
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
-        bvalues=np.array(self.bvalues)
+        bvalues=self.bvalues
         fit_results = self.OGC_algorithm(bvalues, signals, p0=initial_guess, bounds=bounds, fitS0=self.fitS0)
 
         results = {}

--- a/src/standardized/OGC_AmsterdamUMC_biexp.py
+++ b/src/standardized/OGC_AmsterdamUMC_biexp.py
@@ -51,12 +51,11 @@ class OGC_AmsterdamUMC_biexp(OsipiBase):
         self.use_initial_guess = {"f" : True, "D" : True, "Dp" : True, "S0" : True}
         self.use_bounds = {"f" : True, "D" : True, "Dp" : True, "S0" : True}
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -66,7 +65,7 @@ class OGC_AmsterdamUMC_biexp(OsipiBase):
 
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
-        bvalues=np.array(bvalues)
+        bvalues=np.array(self.bvalues)
         fit_results = self.OGC_algorithm(bvalues, signals, p0=initial_guess, bounds=bounds, fitS0=self.fitS0)
 
         results = {}

--- a/src/standardized/OGC_AmsterdamUMC_biexp_segmented.py
+++ b/src/standardized/OGC_AmsterdamUMC_biexp_segmented.py
@@ -72,7 +72,7 @@ class OGC_AmsterdamUMC_biexp_segmented(OsipiBase):
 
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
-        bvalues = np.array(self.bvalues)
+        bvalues = self.bvalues
         fit_results = self.OGC_algorithm(bvalues, signals, bounds=bounds, cutoff=self.thresholds, p0=initial_guess)
 
         results = {}

--- a/src/standardized/OGC_AmsterdamUMC_biexp_segmented.py
+++ b/src/standardized/OGC_AmsterdamUMC_biexp_segmented.py
@@ -72,8 +72,7 @@ class OGC_AmsterdamUMC_biexp_segmented(OsipiBase):
 
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
-        bvalues = self.bvalues
-        fit_results = self.OGC_algorithm(bvalues, signals, bounds=bounds, cutoff=self.thresholds, p0=initial_guess)
+        fit_results = self.OGC_algorithm(self.bvalues, signals, bounds=bounds, cutoff=self.thresholds, p0=initial_guess)
 
         results = {}
         results["D"] = fit_results[0]

--- a/src/standardized/OGC_AmsterdamUMC_biexp_segmented.py
+++ b/src/standardized/OGC_AmsterdamUMC_biexp_segmented.py
@@ -58,12 +58,11 @@ class OGC_AmsterdamUMC_biexp_segmented(OsipiBase):
         else:
             self.thresholds = thresholds
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -73,7 +72,7 @@ class OGC_AmsterdamUMC_biexp_segmented(OsipiBase):
 
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
-        bvalues=np.array(bvalues)
+        bvalues = np.array(self.bvalues)
         fit_results = self.OGC_algorithm(bvalues, signals, bounds=bounds, cutoff=self.thresholds, p0=initial_guess)
 
         results = {}

--- a/src/standardized/OJ_GU_bayesMATLAB.py
+++ b/src/standardized/OJ_GU_bayesMATLAB.py
@@ -68,12 +68,11 @@ class OJ_GU_bayesMATLAB(OsipiBase):
         out = self.eng.IVIM_bayes(Y, f, D, Dstar, S0, b, lim, nargout=1)
         return out['D']['mode'], out['f']['mode'], out['Dstar']['mode'], out['S0']['mode']
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -84,7 +83,7 @@ class OJ_GU_bayesMATLAB(OsipiBase):
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
         fit_results = self.algorithm(np.array(signals)[:,np.newaxis], 
-                                     np.array(bvalues), 
+                                     np.array(self.bvalues), 
                                      np.array(bounds)[:,[1,0,2,3]], 
                                      self.thresholds,
                                      initial_guess)

--- a/src/standardized/OJ_GU_bayesMATLAB.py
+++ b/src/standardized/OJ_GU_bayesMATLAB.py
@@ -83,7 +83,7 @@ class OJ_GU_bayesMATLAB(OsipiBase):
         initial_guess = [self.initial_guess["D"], self.initial_guess["f"], self.initial_guess["Dp"], self.initial_guess["S0"]]
 
         fit_results = self.algorithm(np.array(signals)[:,np.newaxis], 
-                                     np.array(self.bvalues), 
+                                     self.bvalues, 
                                      np.array(bounds)[:,[1,0,2,3]], 
                                      self.thresholds,
                                      initial_guess)

--- a/src/standardized/OJ_GU_seg.py
+++ b/src/standardized/OJ_GU_seg.py
@@ -49,21 +49,17 @@ class OJ_GU_seg(OsipiBase):
         # Initialize the algorithm
         
     
-    def ivim_fit(self, signals, bvalues=None):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
         """
         
-        if bvalues is None:
-            bvalues = self.bvalues
-        else:
-            bvalues = np.asarray(bvalues)
+        bvalues = np.asarray(self.bvalues)
 
         if self.thresholds is None:
             bthr = 200

--- a/src/standardized/OJ_GU_seg.py
+++ b/src/standardized/OJ_GU_seg.py
@@ -59,14 +59,12 @@ class OJ_GU_seg(OsipiBase):
             _type_: _description_
         """
         
-        bvalues = self.bvalues
-
         if self.thresholds is None:
             bthr = 200
         else:
             bthr = self.thresholds[0]
         signals[signals<0.00001]=0.00001
-        fit_results = seg(signals, bvalues, bthr)
+        fit_results = seg(signals, self.bvalues, bthr)
 
         results = {} 
         results["f"] = fit_results['f']

--- a/src/standardized/OJ_GU_seg.py
+++ b/src/standardized/OJ_GU_seg.py
@@ -59,7 +59,7 @@ class OJ_GU_seg(OsipiBase):
             _type_: _description_
         """
         
-        bvalues = np.asarray(self.bvalues)
+        bvalues = self.bvalues
 
         if self.thresholds is None:
             bthr = 200

--- a/src/standardized/OJ_GU_segMATLAB.py
+++ b/src/standardized/OJ_GU_segMATLAB.py
@@ -65,12 +65,11 @@ class OJ_GU_segMATLAB(OsipiBase):
         return pars['D'], pars['f'], pars['Dstar'], pars['S0']
 
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -79,7 +78,7 @@ class OJ_GU_segMATLAB(OsipiBase):
                   [self.bounds["D"][1], self.bounds["f"][1], self.bounds["Dp"][1], self.bounds["S0"][1]])
 
         fit_results = self.algorithm(np.array(signals)[:,np.newaxis], 
-                                     np.array(bvalues), 
+                                     np.array(self.bvalues), 
                                      np.array(bounds)[:,[0,3,1,2]], 
                                      self.thresholds)
 

--- a/src/standardized/OJ_GU_segMATLAB.py
+++ b/src/standardized/OJ_GU_segMATLAB.py
@@ -78,7 +78,7 @@ class OJ_GU_segMATLAB(OsipiBase):
                   [self.bounds["D"][1], self.bounds["f"][1], self.bounds["Dp"][1], self.bounds["S0"][1]])
 
         fit_results = self.algorithm(np.array(signals)[:,np.newaxis], 
-                                     np.array(self.bvalues), 
+                                     self.bvalues, 
                                      np.array(bounds)[:,[0,3,1,2]], 
                                      self.thresholds)
 

--- a/src/standardized/PV_MUMC_biexp.py
+++ b/src/standardized/PV_MUMC_biexp.py
@@ -44,26 +44,16 @@ class PV_MUMC_biexp(OsipiBase):
         self.use_initial_guess = {"f" : False, "D" : False, "Dp" : False, "S0" : False}
         
 
-    def ivim_fit(self, signals, bvalues=None):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             dict: Fitted IVIM parameters f, Dp (D*), and D.
         """
-        # --- bvalues resolution ---
-        # Edge case: bvalues not passed here → fall back to the ones set at __init__ time
-        if bvalues is None:
-            if self.bvalues is None:
-                raise ValueError(
-                    "PV_MUMC_biexp: bvalues must be provided either at initialization or at fit time."
-                )
-            bvalues = self.bvalues
-        else:
-            bvalues = np.asarray(bvalues)
+        bvalues = np.asarray(self.bvalues)
 
         # --- Bounds resolution ---
         # self.bounds is always a dict (OsipiBase force_default_settings=True).

--- a/src/standardized/PV_MUMC_biexp.py
+++ b/src/standardized/PV_MUMC_biexp.py
@@ -53,7 +53,6 @@ class PV_MUMC_biexp(OsipiBase):
         Returns:
             dict: Fitted IVIM parameters f, Dp (D*), and D.
         """
-        bvalues = self.bvalues
 
         # --- Bounds resolution ---
         # self.bounds is always a dict (OsipiBase force_default_settings=True).
@@ -74,7 +73,7 @@ class PV_MUMC_biexp(OsipiBase):
         DEFAULT_PARAMS = [0, 0, 0]
 
         try:
-            fit_results = self.PV_algorithm(bvalues, signals, bounds=bounds, cutoff=self.thresholds)
+            fit_results = self.PV_algorithm(self.bvalues, signals, bounds=bounds, cutoff=self.thresholds)
         except RuntimeError as e:
             # curve_fit raises RuntimeError both for max-evaluations exceeded and other failures
             print(f"PV_MUMC_biexp: optimizer failed ({e}). Returning default parameters.")

--- a/src/standardized/PV_MUMC_biexp.py
+++ b/src/standardized/PV_MUMC_biexp.py
@@ -53,7 +53,7 @@ class PV_MUMC_biexp(OsipiBase):
         Returns:
             dict: Fitted IVIM parameters f, Dp (D*), and D.
         """
-        bvalues = np.asarray(self.bvalues)
+        bvalues = self.bvalues
 
         # --- Bounds resolution ---
         # self.bounds is always a dict (OsipiBase force_default_settings=True).

--- a/src/standardized/PvH_KB_NKI_IVIMfit.py
+++ b/src/standardized/PvH_KB_NKI_IVIMfit.py
@@ -52,18 +52,17 @@ class PvH_KB_NKI_IVIMfit(OsipiBase):
         self.use_initial_guess = {"f" : False, "D" : False, "Dp" : False, "S0" : False}
 
 
-    def ivim_fit(self, signals, bvalues=None):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
         """
         #bvalues = np.array(bvalues)
-        bvalues = bvalues.tolist() #NKI code expects a list instead of nparray
+        bvalues = np.asarray(self.bvalues).tolist() #NKI code expects a list instead of nparray
         # reshape signal as the NKI code expects a 4D array
         signals[signals<0.00001]=0.00001
         signals = np.reshape(signals, (1, 1, 1, len(signals)))  # assuming that in this test the signals are always single voxel

--- a/src/standardized/PvH_KB_NKI_IVIMfit.py
+++ b/src/standardized/PvH_KB_NKI_IVIMfit.py
@@ -62,7 +62,7 @@ class PvH_KB_NKI_IVIMfit(OsipiBase):
             _type_: _description_
         """
         #bvalues = np.array(bvalues)
-        bvalues = np.asarray(self.bvalues).tolist() #NKI code expects a list instead of nparray
+        bvalues = self.bvalues.tolist() #NKI code expects a list instead of nparray
         # reshape signal as the NKI code expects a 4D array
         signals[signals<0.00001]=0.00001
         signals = np.reshape(signals, (1, 1, 1, len(signals)))  # assuming that in this test the signals are always single voxel

--- a/src/standardized/PvH_KB_NKI_IVIMfit.py
+++ b/src/standardized/PvH_KB_NKI_IVIMfit.py
@@ -61,12 +61,10 @@ class PvH_KB_NKI_IVIMfit(OsipiBase):
         Returns:
             _type_: _description_
         """
-        #bvalues = np.array(bvalues)
-        bvalues = self.bvalues.tolist() #NKI code expects a list instead of nparray
         # reshape signal as the NKI code expects a 4D array
         signals[signals<0.00001]=0.00001
         signals = np.reshape(signals, (1, 1, 1, len(signals)))  # assuming that in this test the signals are always single voxel
-        fit_results = self.NKI_algorithm(signals,bvalues)
+        fit_results = self.NKI_algorithm(signals, self.bvalues.tolist())
 
         results = {}
         results["D"] = fit_results[0][0,0,0]/1000

--- a/src/standardized/Super_IVIM_DC.py
+++ b/src/standardized/Super_IVIM_DC.py
@@ -88,18 +88,15 @@ class Super_IVIM_DC(OsipiBase):
         )
 
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             results: a dictionary containing "d", "f", and "Dp".
         """
-        if not np.array_equal(bvalues, self.bvalues):
-            raise ValueError("bvalue list at fitting must be identical as the one at initiation, otherwise it will not run")
 
         Dp, Dt, f, S0_superivimdc = infer_from_signal(
             signal=signals,
@@ -115,18 +112,15 @@ class Super_IVIM_DC(OsipiBase):
         return results
 
 
-    def ivim_fit_full_volume(self, signals, bvalues, retrain_on_input_data=False, **kwargs):
+    def ivim_fit_full_volume(self, signals, retrain_on_input_data=False, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
         """
-        if not np.array_equal(bvalues, self.bvalues):
-            raise ValueError("bvalue list at fitting must be identical as the one at initiation, otherwise it will not run")
 
         nanmask = np.any(np.isnan(signals),axis=-1)
         signals,shape = self.reshape_to_voxelwise(signals)

--- a/src/standardized/TCML_TechnionIIT_SLS.py
+++ b/src/standardized/TCML_TechnionIIT_SLS.py
@@ -69,7 +69,7 @@ class TCML_TechnionIIT_SLS(OsipiBase):
             _type_: _description_
         """
 
-        bvalues=np.array(self.bvalues)
+        bvalues=self.bvalues
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         signals[signals<0]=0

--- a/src/standardized/TCML_TechnionIIT_SLS.py
+++ b/src/standardized/TCML_TechnionIIT_SLS.py
@@ -59,18 +59,17 @@ class TCML_TechnionIIT_SLS(OsipiBase):
         else:
             self.thresholds = thresholds
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
         """
 
-        bvalues=np.array(bvalues)
+        bvalues=np.array(self.bvalues)
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         signals[signals<0]=0

--- a/src/standardized/TCML_TechnionIIT_SLS.py
+++ b/src/standardized/TCML_TechnionIIT_SLS.py
@@ -69,12 +69,11 @@ class TCML_TechnionIIT_SLS(OsipiBase):
             _type_: _description_
         """
 
-        bvalues=self.bvalues
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         signals[signals<0]=0
 
-        fit_results = self.fit_least_squares(np.array(signals)[:,np.newaxis],bvalues, bounds, min_bval_high=self.thresholds)
+        fit_results = self.fit_least_squares(np.array(signals)[:,np.newaxis],self.bvalues, bounds, min_bval_high=self.thresholds)
 
         def get_scalar(val):
             """Convert value to Python scalar, handling numpy arrays."""

--- a/src/standardized/TCML_TechnionIIT_lsqBOBYQA.py
+++ b/src/standardized/TCML_TechnionIIT_lsqBOBYQA.py
@@ -69,12 +69,11 @@ class TCML_TechnionIIT_lsqBOBYQA(OsipiBase):
             _type_: _description_
         """
 
-        bvalues=self.bvalues
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         initial_guess = [self.initial_guess["D"], self.initial_guess["Dp"], self.initial_guess["f"], self.initial_guess["S0"]]
 
-        fit_results = self.fit_least_squares(bvalues, np.array(signals)[:,np.newaxis], bounds, initial_guess.copy())
+        fit_results = self.fit_least_squares(self.bvalues, np.array(signals)[:,np.newaxis], bounds, initial_guess.copy())
 
         def get_scalar(val):
             """Convert value to Python scalar, handling numpy arrays."""

--- a/src/standardized/TCML_TechnionIIT_lsqBOBYQA.py
+++ b/src/standardized/TCML_TechnionIIT_lsqBOBYQA.py
@@ -69,7 +69,7 @@ class TCML_TechnionIIT_lsqBOBYQA(OsipiBase):
             _type_: _description_
         """
 
-        bvalues=np.array(self.bvalues)
+        bvalues=self.bvalues
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         initial_guess = [self.initial_guess["D"], self.initial_guess["Dp"], self.initial_guess["f"], self.initial_guess["S0"]]

--- a/src/standardized/TCML_TechnionIIT_lsqBOBYQA.py
+++ b/src/standardized/TCML_TechnionIIT_lsqBOBYQA.py
@@ -59,18 +59,17 @@ class TCML_TechnionIIT_lsqBOBYQA(OsipiBase):
             self.use_initial_guess = {"f": True, "Dp": True, "D": True}
         self.fitS0=fitS0
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
         """
 
-        bvalues=np.array(bvalues)
+        bvalues=np.array(self.bvalues)
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         initial_guess = [self.initial_guess["D"], self.initial_guess["Dp"], self.initial_guess["f"], self.initial_guess["S0"]]

--- a/src/standardized/TCML_TechnionIIT_lsq_sls_BOBYQA.py
+++ b/src/standardized/TCML_TechnionIIT_lsq_sls_BOBYQA.py
@@ -58,18 +58,17 @@ class TCML_TechnionIIT_lsq_sls_BOBYQA(OsipiBase):
         self.use_bounds = {"f" : True, "D" : True, "Dp" : True, "S0" : True}
         self.use_initial_guess = {"f" : False, "D" : False, "Dp" : False, "S0" : False}
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
         """
         signals[signals<0]=0
-        bvalues=np.array(bvalues)
+        bvalues = np.array(self.bvalues)
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         

--- a/src/standardized/TCML_TechnionIIT_lsq_sls_BOBYQA.py
+++ b/src/standardized/TCML_TechnionIIT_lsq_sls_BOBYQA.py
@@ -68,7 +68,6 @@ class TCML_TechnionIIT_lsq_sls_BOBYQA(OsipiBase):
             _type_: _description_
         """
         signals[signals<0]=0
-        bvalues = self.bvalues
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         
@@ -78,7 +77,7 @@ class TCML_TechnionIIT_lsq_sls_BOBYQA(OsipiBase):
                 return float(val.item())
             return float(val)
 
-        fit_results = self.fit_least_squares(np.array(signals)[:,np.newaxis],bvalues, bounds,min_bval_high=self.thresholds)
+        fit_results = self.fit_least_squares(np.array(signals)[:,np.newaxis],self.bvalues, bounds,min_bval_high=self.thresholds)
 
         results = {}
         if fit_results[0].size > 0:

--- a/src/standardized/TCML_TechnionIIT_lsq_sls_BOBYQA.py
+++ b/src/standardized/TCML_TechnionIIT_lsq_sls_BOBYQA.py
@@ -68,7 +68,7 @@ class TCML_TechnionIIT_lsq_sls_BOBYQA(OsipiBase):
             _type_: _description_
         """
         signals[signals<0]=0
-        bvalues = np.array(self.bvalues)
+        bvalues = self.bvalues
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         

--- a/src/standardized/TCML_TechnionIIT_lsq_sls_lm.py
+++ b/src/standardized/TCML_TechnionIIT_lsq_sls_lm.py
@@ -70,7 +70,7 @@ class TCML_TechnionIIT_lsq_sls_lm(OsipiBase):
             _type_: _description_
         """
         signals[signals<0]=0
-        bvalues=np.array(self.bvalues)
+        bvalues=self.bvalues
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         fit_results = self.fit_least_squares(np.array(signals)[:,np.newaxis],bvalues, bounds, min_bval_high=self.thresholds)

--- a/src/standardized/TCML_TechnionIIT_lsq_sls_lm.py
+++ b/src/standardized/TCML_TechnionIIT_lsq_sls_lm.py
@@ -70,10 +70,9 @@ class TCML_TechnionIIT_lsq_sls_lm(OsipiBase):
             _type_: _description_
         """
         signals[signals<0]=0
-        bvalues=self.bvalues
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
-        fit_results = self.fit_least_squares(np.array(signals)[:,np.newaxis],bvalues, bounds, min_bval_high=self.thresholds)
+        fit_results = self.fit_least_squares(np.array(signals)[:,np.newaxis],self.bvalues, bounds, min_bval_high=self.thresholds)
 
         def get_scalar(val):
             """Convert value to Python scalar, handling numpy arrays."""

--- a/src/standardized/TCML_TechnionIIT_lsq_sls_lm.py
+++ b/src/standardized/TCML_TechnionIIT_lsq_sls_lm.py
@@ -60,18 +60,17 @@ class TCML_TechnionIIT_lsq_sls_lm(OsipiBase):
         self.fitS0=fitS0
         self.use_initial_guess = {"f": False, "Dp": False, "D": False}
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
         """
         signals[signals<0]=0
-        bvalues=np.array(bvalues)
+        bvalues=np.array(self.bvalues)
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         fit_results = self.fit_least_squares(np.array(signals)[:,np.newaxis],bvalues, bounds, min_bval_high=self.thresholds)

--- a/src/standardized/TCML_TechnionIIT_lsq_sls_trf.py
+++ b/src/standardized/TCML_TechnionIIT_lsq_sls_trf.py
@@ -62,18 +62,17 @@ class TCML_TechnionIIT_lsq_sls_trf(OsipiBase):
             self.thresholds = thresholds
         self.fitS0=fitS0
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
         """
         signals[signals<0]=0
-        bvalues=np.array(bvalues)
+        bvalues=np.array(self.bvalues)
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         fit_results = self.fit_least_squares(np.array(signals)[:,np.newaxis],bvalues, bounds,min_bval_high=self.thresholds)

--- a/src/standardized/TCML_TechnionIIT_lsq_sls_trf.py
+++ b/src/standardized/TCML_TechnionIIT_lsq_sls_trf.py
@@ -72,10 +72,9 @@ class TCML_TechnionIIT_lsq_sls_trf(OsipiBase):
             _type_: _description_
         """
         signals[signals<0]=0
-        bvalues=self.bvalues
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
-        fit_results = self.fit_least_squares(np.array(signals)[:,np.newaxis],bvalues, bounds,min_bval_high=self.thresholds)
+        fit_results = self.fit_least_squares(np.array(signals)[:,np.newaxis],self.bvalues, bounds,min_bval_high=self.thresholds)
 
         def get_scalar(val):
             """Convert value to Python scalar, handling numpy arrays."""

--- a/src/standardized/TCML_TechnionIIT_lsq_sls_trf.py
+++ b/src/standardized/TCML_TechnionIIT_lsq_sls_trf.py
@@ -72,7 +72,7 @@ class TCML_TechnionIIT_lsq_sls_trf(OsipiBase):
             _type_: _description_
         """
         signals[signals<0]=0
-        bvalues=np.array(self.bvalues)
+        bvalues=self.bvalues
         bounds = ([self.bounds["D"][0], self.bounds["Dp"][0], self.bounds["f"][0], self.bounds["S0"][0]],
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         fit_results = self.fit_least_squares(np.array(signals)[:,np.newaxis],bvalues, bounds,min_bval_high=self.thresholds)

--- a/src/standardized/TCML_TechnionIIT_lsqlm.py
+++ b/src/standardized/TCML_TechnionIIT_lsqlm.py
@@ -56,18 +56,17 @@ class TCML_TechnionIIT_lsqlm(OsipiBase):
             self.use_initial_guess = {"f": True, "Dp": True, "D": True}
         self.fitS0=fitS0
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
         """
 
-        bvalues=np.array(bvalues)
+        bvalues=np.array(self.bvalues)
         initial_guess = [self.initial_guess["D"], self.initial_guess["Dp"], self.initial_guess["f"], self.initial_guess["S0"]]
         fit_results = self.fit_least_squares(bvalues, np.array(signals)[:,np.newaxis], initial_guess)
 

--- a/src/standardized/TCML_TechnionIIT_lsqlm.py
+++ b/src/standardized/TCML_TechnionIIT_lsqlm.py
@@ -66,9 +66,8 @@ class TCML_TechnionIIT_lsqlm(OsipiBase):
             _type_: _description_
         """
 
-        bvalues=self.bvalues
         initial_guess = [self.initial_guess["D"], self.initial_guess["Dp"], self.initial_guess["f"], self.initial_guess["S0"]]
-        fit_results = self.fit_least_squares(bvalues, np.array(signals)[:,np.newaxis], initial_guess)
+        fit_results = self.fit_least_squares(self.bvalues, np.array(signals)[:,np.newaxis], initial_guess)
 
         def get_scalar(val):
             """Convert value to Python scalar, handling numpy arrays."""

--- a/src/standardized/TCML_TechnionIIT_lsqlm.py
+++ b/src/standardized/TCML_TechnionIIT_lsqlm.py
@@ -66,7 +66,7 @@ class TCML_TechnionIIT_lsqlm(OsipiBase):
             _type_: _description_
         """
 
-        bvalues=np.array(self.bvalues)
+        bvalues=self.bvalues
         initial_guess = [self.initial_guess["D"], self.initial_guess["Dp"], self.initial_guess["f"], self.initial_guess["S0"]]
         fit_results = self.fit_least_squares(bvalues, np.array(signals)[:,np.newaxis], initial_guess)
 

--- a/src/standardized/TCML_TechnionIIT_lsqtrf.py
+++ b/src/standardized/TCML_TechnionIIT_lsqtrf.py
@@ -73,8 +73,7 @@ class TCML_TechnionIIT_lsqtrf(OsipiBase):
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         initial_guess = [self.initial_guess["D"], self.initial_guess["Dp"], self.initial_guess["f"], self.initial_guess["S0"]]
 
-        bvalues = self.bvalues
-        fit_results = self.fit_least_squares(bvalues, np.array(signals)[:,np.newaxis], bounds,initial_guess)
+        fit_results = self.fit_least_squares(self.bvalues, np.array(signals)[:,np.newaxis], bounds,initial_guess)
 
         def get_scalar(val):
             """Convert value to Python scalar, handling numpy arrays."""

--- a/src/standardized/TCML_TechnionIIT_lsqtrf.py
+++ b/src/standardized/TCML_TechnionIIT_lsqtrf.py
@@ -60,12 +60,11 @@ class TCML_TechnionIIT_lsqtrf(OsipiBase):
 
         self.fitS0=fitS0
 
-    def ivim_fit(self, signals, bvalues, **kwargs):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -74,7 +73,7 @@ class TCML_TechnionIIT_lsqtrf(OsipiBase):
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         initial_guess = [self.initial_guess["D"], self.initial_guess["Dp"], self.initial_guess["f"], self.initial_guess["S0"]]
 
-        bvalues=np.array(bvalues)
+        bvalues = np.array(self.bvalues)
         fit_results = self.fit_least_squares(bvalues, np.array(signals)[:,np.newaxis], bounds,initial_guess)
 
         def get_scalar(val):

--- a/src/standardized/TCML_TechnionIIT_lsqtrf.py
+++ b/src/standardized/TCML_TechnionIIT_lsqtrf.py
@@ -73,7 +73,7 @@ class TCML_TechnionIIT_lsqtrf(OsipiBase):
                        [self.bounds["D"][1], self.bounds["Dp"][1], self.bounds["f"][1], self.bounds["S0"][1]])
         initial_guess = [self.initial_guess["D"], self.initial_guess["Dp"], self.initial_guess["f"], self.initial_guess["S0"]]
 
-        bvalues = np.array(self.bvalues)
+        bvalues = self.bvalues
         fit_results = self.fit_least_squares(bvalues, np.array(signals)[:,np.newaxis], bounds,initial_guess)
 
         def get_scalar(val):

--- a/src/standardized/TF_reference_IVIMfit.py
+++ b/src/standardized/TF_reference_IVIMfit.py
@@ -69,7 +69,7 @@ class TF_reference_IVIMfit(OsipiBase):
         bounds = ([self.bounds["D"][0], self.bounds["f"][0], self.bounds["Dp"][0], self.bounds["S0"][0]],
                   [self.bounds["D"][1], self.bounds["f"][1], self.bounds["Dp"][1], self.bounds["S0"][1]])
 
-        bvalues = np.array(self.bvalues)
+        bvalues = self.bvalues
 
         if np.any(signals < 0):
             signals = np.clip(signals,0.01, None)

--- a/src/standardized/TF_reference_IVIMfit.py
+++ b/src/standardized/TF_reference_IVIMfit.py
@@ -57,12 +57,11 @@ class TF_reference_IVIMfit(OsipiBase):
             self.thresholds = thresholds
 
 
-    def ivim_fit(self, signals, bvalues=None):
+    def ivim_fit(self, signals, **kwargs):
         """Perform the IVIM fit
 
         Args:
             signals (array-like)
-            bvalues (array-like, optional): b-values for the signals. If None, self.bvalues will be used. Default is None.
 
         Returns:
             _type_: _description_
@@ -70,7 +69,7 @@ class TF_reference_IVIMfit(OsipiBase):
         bounds = ([self.bounds["D"][0], self.bounds["f"][0], self.bounds["Dp"][0], self.bounds["S0"][0]],
                   [self.bounds["D"][1], self.bounds["f"][1], self.bounds["Dp"][1], self.bounds["S0"][1]])
 
-        bvalues = np.array(bvalues)
+        bvalues = np.array(self.bvalues)
 
         if np.any(signals < 0):
             signals = np.clip(signals,0.01, None)

--- a/src/standardized/TF_reference_IVIMfit.py
+++ b/src/standardized/TF_reference_IVIMfit.py
@@ -69,14 +69,12 @@ class TF_reference_IVIMfit(OsipiBase):
         bounds = ([self.bounds["D"][0], self.bounds["f"][0], self.bounds["Dp"][0], self.bounds["S0"][0]],
                   [self.bounds["D"][1], self.bounds["f"][1], self.bounds["Dp"][1], self.bounds["S0"][1]])
 
-        bvalues = self.bvalues
 
         if np.any(signals < 0):
             signals = np.clip(signals,0.01, None)
             warnings.warn('Negative values in signal: values clipped to 0.01', UserWarning, stacklevel=2)
 
-
-        fit_results = self.TF_reference_algorithm(bvalues,signals,b_cutoff=self.thresholds, bounds=bounds)
+        fit_results = self.TF_reference_algorithm(self.bvalues,signals,b_cutoff=self.thresholds, bounds=bounds)
 
         results = {}
         results["D"] = fit_results[0]

--- a/src/wrappers/OsipiBase.py
+++ b/src/wrappers/OsipiBase.py
@@ -80,10 +80,10 @@ class OsipiBase:
     osipi_initiate_algorithm(algorithm, **kwargs)
         Dynamically replace the current instance with the specified
         algorithm subclass.
-    osipi_fit(data, bvalues=None, njobs=1, **kwargs)
+    osipi_fit(data, njobs=1, **kwargs)
         Voxel-wise IVIM fitting with optional parallel processing and
         automatic signal normalization.
-    osipi_fit_full_volume(data, bvalues=None, **kwargs)
+    osipi_fit_full_volume(data, **kwargs)
         Full-volume fitting for algorithms that support it.
     osipi_print_requirements()
         Display algorithm requirements such as needed b-values or bounds.
@@ -91,7 +91,7 @@ class OsipiBase:
         Query acceptable input dimensionalities.
     osipi_check_required_*()
         Validate that provided inputs meet algorithm requirements.
-    osipi_simple_bias_and_RMSE_test(SNR, bvalues, f, Dstar, D, noise_realizations)
+    osipi_simple_bias_and_RMSE_test(SNR, f, Dstar, D, noise_realizations)
         Monte-Carlo bias/RMSE evaluation of the current fitting method.
     D_and_Ds_swap(results)
         Ensure consistency of D and D* estimates by swapping if necessary.
@@ -239,8 +239,7 @@ class OsipiBase:
         """Placeholder for subclass initialization"""
         pass
 
-    #def osipi_fit(self, data=None, bvalues=None, thresholds=None, bounds=None, initial_guess=None, **kwargs):
-    def osipi_fit(self, data, bvalues=None, njobs=1, **kwargs):
+    def osipi_fit(self, data, njobs=1, **kwargs):
         """
         Fit multi-b-value diffusion MRI data using the IVIM model.
 
@@ -253,9 +252,6 @@ class OsipiBase:
         data : np.ndarray
             Multi-dimensional array containing the signal intensities. The last dimension must correspond
             to the b-values (diffusion weightings).
-        bvalues : array-like, optional
-            Array of b-values corresponding to the last dimension of `data`. If not provided, the method
-            uses `self.bvalues` set during object initialization.
         njobs : int, optional, default=1
             Number of parallel jobs to use for voxel-wise fitting. If `njobs` > 1, the fitting will be
             distributed across multiple processes. -1 will use all available cpus
@@ -279,40 +275,18 @@ class OsipiBase:
 
         Example
         -------
-        >>> results = instance.osipi_fit(data, bvalues=[0, 50, 200, 800], njobs=4)
+        >>> results = instance.osipi_fit(data, njobs=4)
         >>> f_map = results['f']
         >>> D_map = results['D']
         """
         
-        # We should first check whether the attributes in the __init__ are not None
-        # Then check if they are input here, if they are, these should overwrite the attributes
-        use_bvalues = bvalues if bvalues is not None else self.bvalues
-        #use_thresholds = thresholds if self.thresholds is None else self.thresholds
-        #use_bounds = bounds if self.bounds is None else self.bounds
-        #use_initial_guess = initial_guess if self.initial_guess is None else self.initial_guess
-
-        # Make sure we don't make arrays of None's
-        if use_bvalues is not None: use_bvalues = np.asarray(use_bvalues) 
-        #if use_thresholds is not None: use_thresholds = np.asarray(use_thresholds) 
-        #if use_bounds is not None: use_bounds = np.asarray(use_bounds) 
-        #if use_initial_guess is not None: use_initial_guess = np.asarray(use_initial_guess) 
-        #kwargs["bvalues"] = use_bvalues
-        
-        #args = [data, use_bvalues, use_thresholds]
-        #if self.required_bounds or self.required_bounds_optional:
-            #args.append(use_bounds)
-        #if self.required_initial_guess or self.required_initial_guess_optional:
-            #args.append(use_initial_guess)
-            
-        # Run a check_requirements method that makes sure that these inputs fulfil the requirements
-        
-        
-        # Then we check which inputs are required for the algorithm using the requirements attributes in the template 
-        
-        # Then we pass everything into the ivim_fit method which performs the fit according to the algorithm
-        
-        #args = [data, use_bvalues, use_initial_guess, use_bounds, use_thresholds]
-        #args = [arg for arg in args if arg is not None]
+        # b-values must be provided at initialization, not at fit-time.
+        if self.bvalues is None:
+            raise ValueError(
+                "b-values must be provided at initialization (__init__), not at fit-time. "
+                "Pass bvalues to the constructor: OsipiBase(bvalues=..., algorithm=...)"
+            )
+        use_bvalues = np.asarray(self.bvalues)
 
         # Check if there is an attribute that defines the result dictionary keys
         if hasattr(self, "result_keys"):
@@ -349,7 +323,7 @@ class OsipiBase:
             def parfun(ijk):
                 single_voxel_data = np.array(data[ijk], copy=True)
                 if not np.isnan(single_voxel_data[0]):
-                    fit = self.ivim_fit(single_voxel_data, use_bvalues, **kwargs)
+                    fit = self.ivim_fit(single_voxel_data, **kwargs)
                 else:
                     fit={'D':0,'f':0,'Dp':0}
                 return ijk, fit
@@ -372,8 +346,7 @@ class OsipiBase:
                 # Normalize array
                 single_voxel_data = data[ijk]
                 if not np.isnan(single_voxel_data[0]):
-                    args = [single_voxel_data, use_bvalues]
-                    fit = self.ivim_fit(*args, **kwargs)
+                    fit = self.ivim_fit(single_voxel_data, **kwargs)
                 else:
                     fit={'D':0,'f':0,'Dp':0}
                 for key in list(fit.keys()):
@@ -382,7 +355,7 @@ class OsipiBase:
         return results
 
 
-    def osipi_fit_full_volume(self, data, bvalues=None, **kwargs):
+    def osipi_fit_full_volume(self, data, **kwargs):
         """
         Fit an entire volume of multi-b-value diffusion MRI data in a single call using the IVIM model.
 
@@ -394,9 +367,6 @@ class OsipiBase:
         data : np.ndarray
             2D (data x b-values), 3D (single slice), or 4D (multi-slice) diffusion-weighted imaging (DWI) data.
             The last dimension must correspond to the b-values.
-        bvalues : array-like, optional
-            Array of b-values corresponding to the last dimension of `data`. If not provided, the method
-            uses `self.bvalues` set during object initialization.
         **kwargs : dict, optional
             Additional keyword arguments to be passed to `ivim_fit_full_volume`.
 
@@ -414,7 +384,7 @@ class OsipiBase:
         Example
         -------
         # Standard usage:
-        results = instance.osipi_fit_full_volume(data, bvalues=[0, 50, 200, 800])
+        results = instance.osipi_fit_full_volume(data)
         f_map = results['f']
         D_map = results['D']
         Dp_map = results['Dp']
@@ -426,8 +396,12 @@ class OsipiBase:
         """
         
         try:
-            use_bvalues = bvalues if bvalues is not None else self.bvalues
-            if use_bvalues is not None: use_bvalues = np.asarray(use_bvalues) 
+            # b-values must be provided at initialization, not at fit-time.
+            if self.bvalues is None:
+                raise ValueError(
+                    "b-values must be provided at initialization (__init__), not at fit-time. "
+                    "Pass bvalues to the constructor: OsipiBase(bvalues=..., algorithm=...)"
+                )
 
             # Check if there is an attribute that defines the result dictionary keys
             if hasattr(self, "result_keys"):
@@ -442,8 +416,7 @@ class OsipiBase:
             for key in self.result_keys:
                 results[key] = np.empty(list(data.shape[:-1]))
             # no normalisation as volume algorithms may not want normalized signals...
-            args = [data, use_bvalues]
-            fit = self.ivim_fit_full_volume(*args, **kwargs) # Assume this is a dict with an array per key representing the parametric maps
+            fit = self.ivim_fit_full_volume(data, **kwargs) # Assume this is a dict with an array per key representing the parametric maps
             for key in list(fit.keys()):
                 results[key] = fit[key]
 
@@ -572,9 +545,9 @@ class OsipiBase:
         """Author identification"""
         return ''
     
-    def osipi_simple_bias_and_RMSE_test(self, SNR, bvalues, f, Dstar, D, noise_realizations=100):
-        # Generate signal
-        bvalues = np.asarray(bvalues)
+    def osipi_simple_bias_and_RMSE_test(self, SNR, f, Dstar, D, noise_realizations=100):
+        # Generate signal using b-values from initialization
+        bvalues = np.asarray(self.bvalues)
         signals = f*np.exp(-bvalues*Dstar) + (1-f)*np.exp(-bvalues*D)
         
         f_estimates = np.zeros(noise_realizations)
@@ -587,7 +560,7 @@ class OsipiBase:
             
             # Perform fit with the noised signal
             # f_estimates[i], Dstar_estimates[i], D_estimates[i] = self.D_and_Ds_swap(self.ivim_fit(noised_signal, bvalues))
-            result = self.ivim_fit(noised_signal, bvalues)
+            result = self.ivim_fit(noised_signal)
             f_estimates[i], Dstar_estimates[i], D_estimates[i] = result['f'], result['Dp'], result['D']
             
         # Calculate bias

--- a/src/wrappers/OsipiBase.py
+++ b/src/wrappers/OsipiBase.py
@@ -286,7 +286,7 @@ class OsipiBase:
                 "b-values must be provided at initialization (__init__), not at fit-time. "
                 "Pass bvalues to the constructor: OsipiBase(bvalues=..., algorithm=...)"
             )
-        use_bvalues = np.asarray(self.bvalues)
+        use_bvalues = self.bvalues
 
         # Check if there is an attribute that defines the result dictionary keys
         if hasattr(self, "result_keys"):
@@ -547,7 +547,7 @@ class OsipiBase:
     
     def osipi_simple_bias_and_RMSE_test(self, SNR, f, Dstar, D, noise_realizations=100):
         # Generate signal using b-values from initialization
-        bvalues = np.asarray(self.bvalues)
+        bvalues = self.bvalues
         signals = f*np.exp(-bvalues*Dstar) + (1-f)*np.exp(-bvalues*D)
         
         f_estimates = np.zeros(noise_realizations)

--- a/src/wrappers/OsipiBase.py
+++ b/src/wrappers/OsipiBase.py
@@ -286,8 +286,7 @@ class OsipiBase:
                 "b-values must be provided at initialization (__init__), not at fit-time. "
                 "Pass bvalues to the constructor: OsipiBase(bvalues=..., algorithm=...)"
             )
-        use_bvalues = self.bvalues
-
+        
         # Check if there is an attribute that defines the result dictionary keys
         if hasattr(self, "result_keys"):
             # result_keys is a list of strings of parameter names, e.g. "S0", "f1", "f2", etc.
@@ -303,11 +302,11 @@ class OsipiBase:
         # Assuming the last dimension of the data is the signal values of each b-value
         # results = np.empty(list(data.shape[:-1])+[3]) # Create an array with the voxel dimensions + the ones required for the fit
         #for ijk in tqdm(np.ndindex(data.shape[:-1]), total=np.prod(data.shape[:-1])):
-            #args = [data[ijk], use_bvalues]
+            #args = [data[ijk], self.bvalues]
             #fit = list(self.ivim_fit(*args, **kwargs))
             #results[ijk] = fit
-        minimum_bvalue = np.min(use_bvalues) # We normalize the signal to the minimum bvalue. Should be 0 or very close to 0.
-        b0_indices = np.where(use_bvalues == minimum_bvalue)[0]
+        minimum_bvalue = np.min(self.bvalues) # We normalize the signal to the minimum bvalue. Should be 0 or very close to 0.
+        b0_indices = np.where(self.bvalues == minimum_bvalue)[0]
         normalization_factor = np.mean(data[..., b0_indices],axis=-1)
         data = data / np.repeat(normalization_factor[...,np.newaxis],np.shape(data)[-1],-1)
         if np.shape(data.shape)[0] == 1:
@@ -547,8 +546,7 @@ class OsipiBase:
     
     def osipi_simple_bias_and_RMSE_test(self, SNR, f, Dstar, D, noise_realizations=100):
         # Generate signal using b-values from initialization
-        bvalues = self.bvalues
-        signals = f*np.exp(-bvalues*Dstar) + (1-f)*np.exp(-bvalues*D)
+        signals = f*np.exp(-self.bvalues*Dstar) + (1-f)*np.exp(-self.bvalues*D)
         
         f_estimates = np.zeros(noise_realizations)
         Dstar_estimates = np.zeros(noise_realizations)

--- a/tests/IVIMmodels/unit_tests/simple_test_run_of_algorithm.py
+++ b/tests/IVIMmodels/unit_tests/simple_test_run_of_algorithm.py
@@ -29,14 +29,14 @@ def dev_test_run(model, **kwargs):
 
     #model = ETP_SRI_LinearFitting(thresholds=[200])
     if kwargs:
-        results = model.osipi_fit(signals, bvalues, **kwargs)
+        results = model.osipi_fit(signals, **kwargs)
     else:
-        results = model.osipi_fit(signals, bvalues)
+        results = model.osipi_fit(signals)
     print(results)
     #test = model.osipi_simple_bias_and_RMSE_test(SNR=20, bvalues=bvalues, f=0.1, Dstar=0.03, D=0.001, noise_realizations=10)
     
 #model1 = ETP_SRI_LinearFitting(thresholds=[200])
-model2 = IAR_LU_biexp()
+model2 = IAR_LU_biexp(bvalues=np.array([0, 50, 0, 100, 0, 150, 200, 500, 0, 800]))
 #model2 = IAR_LU_modified_mix()
 #model2 = OGC_AmsterdamUMC_biexp()
 

--- a/tests/IVIMmodels/unit_tests/test_ivim_fit.py
+++ b/tests/IVIMmodels/unit_tests/test_ivim_fit.py
@@ -51,9 +51,9 @@ def test_ivim_fit_saved(data_ivim_fit_saved, eng, request, record_property):
         test_bounds = {"S0" : [0.7, 1.3], "f" : [0, 1.0], "Dp" : [0.01, 0.2], "D" : [0, 0.005]}
     else:
         test_bounds = {"S0" : [0.7, 1.3], "f" : [0, 1.0], "Dp" : [0.005, 0.2], "D" : [0, 0.005]}
-    fit = OsipiBase(algorithm=algorithm, bounds=test_bounds, **kwargs)
+    fit = OsipiBase(algorithm=algorithm, bvalues=bvals, bounds=test_bounds, **kwargs)
     start_time = time.time()  # Record the start time
-    fit_result = fit.osipi_fit(signal, bvals)
+    fit_result = fit.osipi_fit(signal)
     elapsed_time = time.time() - start_time  # Calculate elapsed time
     def to_list_if_needed(value):
         return value.tolist() if isinstance(value, np.ndarray) else value
@@ -123,10 +123,10 @@ def test_bounds(bound_input, eng, request):
     #bounds = ([0.0008, 0.2, 0.01, 1.1], [0.0012, 0.3, 0.02, 1.3])
     bounds = {"S0" : [1.1, 1.3], "f" : [0.2, 0.3], "Dp" : [0.01, 0.02], "D" : [0.0008, 0.0012]}
     # deliberately have silly bounds to see whether they are used
-    fit = OsipiBase(algorithm=algorithm, bounds=bounds, initial_guess={"S0" : 1.2, "f" : 0.25, "Dp" : 0.015, "D" : 0.001}, **kwargs)
+    fit = OsipiBase(algorithm=algorithm, bvalues=bvals, bounds=bounds, initial_guess={"S0" : 1.2, "f" : 0.25, "Dp" : 0.015, "D" : 0.001}, **kwargs)
     if fit.use_bounds["f"] or fit.use_bounds["D"] or fit.use_bounds["Dp"]:
         signal = signal_helper(data["data"])
-        fit_result = fit.osipi_fit(signal, bvals)
+        fit_result = fit.osipi_fit(signal)
         eps=1e-10 # without this margin it can cause floating point failures on mac systems
         if fit.use_bounds["D"]:
             assert bounds["D"][0]-eps <= fit_result['D'] <= bounds["D"][1]+eps,  f"Result {fit_result['D']} out of bounds for data: {name}"
@@ -185,10 +185,10 @@ def test_volume(algorithmlist,eng, threeddata):
         kwargs = {'bvalues': bvals}
     else:
         kwargs={}
-    fit = OsipiBase(algorithm=algorithm,**kwargs)
+    fit = OsipiBase(algorithm=algorithm, bvalues=bvals, **kwargs)
     if hasattr(fit, 'ivim_fit_full_volume') and callable(getattr(fit, 'ivim_fit_full_volume')):
         start_time = time.time()  # Record the start time
-        fit_result = fit.osipi_fit_full_volume(data, bvals)
+        fit_result = fit.osipi_fit_full_volume(data)
         elapsed_time2 = time.time() - start_time  # Calculate elapsed time
         print('time elaapsed is '+str(elapsed_time2))
         assert np.shape(fit_result['D'])[0] == np.shape(data)[0]
@@ -218,17 +218,17 @@ def test_parallel(algorithmlist,eng,threeddata):
     data[invalid_mask,:] = np.nan
     print('testing ' + str(np.sum(~invalid_mask)) + ' voxels of a matrix size ' + str(np.shape(data)))
 
-    fit = OsipiBase(algorithm=algorithm,**kwargs)
+    fit = OsipiBase(algorithm=algorithm, bvalues=bvals, **kwargs)
 
     def dummy_task(x):
         return x
 
     start_time = time.time()  # Record the start time
-    fit_result = fit.osipi_fit(data, bvals,njobs=1)
+    fit_result = fit.osipi_fit(data, njobs=1)
     time_serial = time.time() - start_time  # Calculate elapsed time
     Parallel(n_jobs=2)(delayed(dummy_task)(i) for i in range(8)) #github actions only supports 2 cores
     start_time = time.time()  # Record the start time
-    fit_result2 = fit.osipi_fit(data, bvals,njobs=2)
+    fit_result2 = fit.osipi_fit(data, njobs=2)
     time_parallel= time.time() - start_time  # Calculate elapsed time
 
     print('singular took '+str(time_serial)+' seconds, and parallel took '+str(time_parallel)+' seconds')
@@ -259,7 +259,7 @@ def test_deep_learning_algorithms(deep_learning_algorithms, record_property):
     fit = OsipiBase(bvalues=bvals, algorithm=algorithm, bounds={"S0" : [0, 2], "f" : [0, 1], "Dp" : [0.005, 0.2], "D" : [0, 0.005]}, **kwargs)
 
     array_2d = np.array([dat["data"] for _, dat in data.items()])
-    fit_result = fit.osipi_fit_full_volume(array_2d, bvals)
+    fit_result = fit.osipi_fit_full_volume(array_2d)
 
     errors = []  # Collect all assertion errors
 

--- a/tests/IVIMmodels/unit_tests/test_ivim_synthetic.py
+++ b/tests/IVIMmodels/unit_tests/test_ivim_synthetic.py
@@ -26,7 +26,7 @@ def test_generated(algorithmlist, ivim_data, SNR, rtol, atol, fit_count, rician_
     D = data["D"]
     f = data["f"]
     Dp = data["Dp"]
-    fit = OsipiBase(algorithm=ivim_algorithm)
+    fit = OsipiBase(algorithm=ivim_algorithm, bvalues=bvals)
     # here is a prior
     if use_prior and hasattr(fit, "supported_priors") and fit.supported_priors:
         prior = [rng.normal(D, D/3, 10), rng.normal(f, f/3, 10), rng.normal(Dp, Dp/3, 10), rng.normal(1, 1/3, 10)]
@@ -39,7 +39,7 @@ def test_generated(algorithmlist, ivim_data, SNR, rtol, atol, fit_count, rician_
         # else:
         #     signal = data["data"]
         start_time = datetime.datetime.now()
-        fit_result = fit.osipi_fit(signal, bvals) #, prior_in=prior
+        fit_result = fit.osipi_fit(signal) #, prior_in=prior
         time_delta += datetime.datetime.now() - start_time
         if save_file is not None:
             save_file.writerow([ivim_algorithm, name, SNR, idx, f, Dp, D, fit_result["f"], fit_result["Dp"], fit_result["D"], *signal])


### PR DESCRIPTION
- Remove bvalues parameter from all 27 algorithm ivim_fit() and ivim_fit_full_volume() signatures in src/standardized/
- All algorithms now access b-values via self.bvalues exclusively
- Add **kwargs to algorithms that lacked it (OJ_GU_seg, PV_MUMC, PvH_KB_NKI, TF_reference)
- OsipiBase.osipi_fit() and osipi_fit_full_volume() enforce ValueError if bvalues not set at init
- Update all test files to pass bvalues at OsipiBase(...) init
- Update WrapImage production wrappers to use new API
- Remove now-redundant bvalue equality checks in DL algorithms

fixes #155 