### PR TITLE
Fix #150: remove duplicate osipi_check_required_bvalues definition

### DIFF
--- a/src/wrappers/OsipiBase.py
+++ b/src/wrappers/OsipiBase.py
@@ -535,11 +535,6 @@ class OsipiBase:
             #return True
         return True
 
-    
-    def osipi_check_required_bvalues(self):
-        """Minimum number of b-values required"""
-        pass
-
     def osipi_author(self):
         """Author identification"""
         return ''

--- a/tests/IVIMmodels/unit_tests/test_ivim_fit.py
+++ b/tests/IVIMmodels/unit_tests/test_ivim_fit.py
@@ -323,3 +323,33 @@ def test_invalid_algorithm_name():
     # A valid algorithm should still work without errors
     fit = OsipiBase(algorithm="IAR_LU_biexp")
     assert fit is not None
+
+
+def test_no_duplicate_method_definitions_in_osipibase():
+    """Regression test for issue #150.
+
+    OsipiBase defined osipi_check_required_bvalues twice. The second definition
+    was a bare `pass` stub that shadowed the first, so the method returned None
+    instead of a boolean. Guard against any method being defined twice, and
+    check that the requirement-checking methods return booleans.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    class_source = textwrap.dedent(inspect.getsource(OsipiBase))
+    class_def = ast.parse(class_source).body[0]
+    method_names = [node.name for node in class_def.body
+                    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))]
+    duplicates = sorted({name for name in method_names if method_names.count(name) > 1})
+    assert not duplicates, f"OsipiBase defines these methods more than once: {duplicates}"
+
+    # The requirement checks must return a boolean, never None
+    fit = OsipiBase(bvalues=np.array([0, 50, 200, 800]))
+    for check in ("osipi_check_required_bvalues",
+                  "osipi_check_required_thresholds",
+                  "osipi_check_required_bounds",
+                  "osipi_check_required_initial_guess"):
+        result = getattr(fit, check)()
+        assert isinstance(result, (bool, np.bool_)), \
+            f"{check}() returned {result!r} ({type(result).__name__}), expected a bool"


### PR DESCRIPTION
### Describe the changes you have made in this PR

`OsipiBase` defined `osipi_check_required_bvalues` **twice**. The second definition was a bare `pass` stub that shadowed the first, so the method returned `None` instead of a boolean.

This PR removes the shadowing stub and adds a regression test so that a duplicate method definition cannot silently reappear.

```diff
@@ -535,11 +535,6 @@ class OsipiBase:
             #return True
         return True
 
-    
-    def osipi_check_required_bvalues(self):
-        """Minimum number of b-values required"""
-        pass
-
     def osipi_author(self):
         """Author identification"""
         return ''
```

The surviving definition returns `True` and is consistent with its three siblings `osipi_check_required_thresholds`, `osipi_check_required_bounds` and `osipi_check_required_initial_guess`.

---

#### Verification

The pre-fix class was loaded directly from git and compared against the fixed one, so the result does not depend on reading the diff correctly:

| | Method definitions | `osipi_check_required_bvalues()` |
|---|---|---|
| Before | 17 (1 duplicate) | `None` |
| After | 16 (no duplicates) | `True` |

The public API is unchanged, and **every remaining method is byte-identical** (`__code__.co_code`) to before, so this change cannot affect any other behaviour.

#### Regression test

`tests/IVIMmodels/unit_tests/test_ivim_fit.py::test_no_duplicate_method_definitions_in_osipibase`

It parses `OsipiBase` with `ast` and asserts that **no** method name is defined more than once — guarding against any future duplicate, not only this one — then asserts that all four `osipi_check_required_*` methods return a boolean rather than `None`.

The test was confirmed to **fail against the pre-fix code** and pass after, so it is a real guard rather than one that passes vacuously. `np.bool_` is accepted alongside `bool` so the test does not obstruct a future real implementation of these checks.

#### Test suite

Run from the repository root (Windows, Python 3.11.3, pytest 9.0.2):

```
python -m pytest -k "not test_volume and not test_parallel" -q

672 passed, 89 skipped, 432 deselected, 11 xfailed, 4 xpassed in 2852.13s (0:47:32)
```

No failures. The skips are the MATLAB-dependent algorithms (no `matlab.engine` locally) and the deep-learning skips; the xfails/xpasses are the pre-existing `TCML_TechnionIIT_lsqBOBYQA` entries from `algorithms.json`.

`test_volume` and `test_parallel` (54 tests) were not run locally, as they require the XCAT phantom downloaded from Zenodo which is not present in my environment. CI covers them, and per the byte-identity check above this change cannot affect them.

---

### Link this PR to an issue [optional]

Fixes #150

### Checklist

- [x] Self-review of changed code
- [x] Added automated tests where applicable
- [ ] Update Docs & Guides — not applicable, no user-facing behaviour change
